### PR TITLE
Fixed priority classes to ensure that doc-workers don't crowd out critical services

### DIFF
--- a/infra/k8s/mcp-server-keda.yaml
+++ b/infra/k8s/mcp-server-keda.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     app: mcp-server
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: mcp-server
@@ -28,7 +28,7 @@ spec:
       labels:
         app: mcp-server
     spec:
-      priorityClassName: worker-normal-priority
+      priorityClassName: service-critical-priority
       containers:
         - name: mcp-server
           image: seanmckdemo.azurecr.io/mcp-server:0.0.8
@@ -70,7 +70,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: mcp-server
-  minReplicaCount: 1
+  minReplicaCount: 2
   maxReplicaCount: 10
   cooldownPeriod: 60
   triggers:

--- a/infra/k8s/priority-classes.yaml
+++ b/infra/k8s/priority-classes.yaml
@@ -1,10 +1,26 @@
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
+  name: infrastructure-critical-priority
+value: 2000
+globalDefault: false
+description: "Critical priority for core infrastructure components (RabbitMQ, Redis)"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
   name: webui-high-priority
 value: 1000
 globalDefault: false
 description: "High priority for user-facing web UI components"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: service-critical-priority
+value: 750
+globalDefault: false
+description: "Critical priority for services that other workers depend on (MCP Server)"
 ---
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass

--- a/infra/k8s/rabbitmq.yaml
+++ b/infra/k8s/rabbitmq.yaml
@@ -39,6 +39,7 @@ spec:
       labels:
         app: rabbitmq
     spec:
+      priorityClassName: infrastructure-critical-priority
       serviceAccountName: sc-account-fefa7dd8-f9d3-4524-8a35-c1123a838df0
       containers:
         - name: rabbitmq

--- a/infra/k8s/redis.yaml
+++ b/infra/k8s/redis.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: redis
     spec:
+      priorityClassName: infrastructure-critical-priority
       containers:
       - name: redis
         image: mcr.microsoft.com/cbl-mariner/base/redis:6.2


### PR DESCRIPTION
This pull request introduces changes to Kubernetes configurations to enhance scaling, prioritization, and resource allocation for critical services. The key updates include increasing replica counts for the MCP Server, introducing new priority classes, and assigning appropriate priority classes to infrastructure components like RabbitMQ and Redis.

### Scaling and Resource Allocation:
* Increased the `replicas` count for the MCP Server from 1 to 2 to improve availability (`infra/k8s/mcp-server-keda.yaml`, [infra/k8s/mcp-server-keda.yamlL22-R22](diffhunk://#diff-081c89c825cb88fdc987ad0b2532541f5198342c4206a32984b3852b70b25164L22-R22)).
* Updated the `minReplicaCount` for the MCP Server's autoscaler from 1 to 2 to ensure a minimum of two replicas are always running (`infra/k8s/mcp-server-keda.yaml`, [infra/k8s/mcp-server-keda.yamlL73-R73](diffhunk://#diff-081c89c825cb88fdc987ad0b2532541f5198342c4206a32984b3852b70b25164L73-R73)).

### Priority Class Enhancements:
* Added a new `infrastructure-critical-priority` class with a value of 2000 for core infrastructure components like RabbitMQ and Redis (`infra/k8s/priority-classes.yaml`, [infra/k8s/priority-classes.yamlR3-R10](diffhunk://#diff-be6011711cdf8e41bea6e08bd9cdeab7ff75db6f42754fb5b9fa87aa5c4d4a6dR3-R10)).
* Added a new `service-critical-priority` class with a value of 750 for services that other workers depend on, such as the MCP Server (`infra/k8s/priority-classes.yaml`, [infra/k8s/priority-classes.yamlR19-R26](diffhunk://#diff-be6011711cdf8e41bea6e08bd9cdeab7ff75db6f42754fb5b9fa87aa5c4d4a6dR19-R26)).

### Priority Class Assignments:
* Updated the MCP Server to use the `service-critical-priority` class to reflect its importance to dependent workers (`infra/k8s/mcp-server-keda.yaml`, [infra/k8s/mcp-server-keda.yamlL31-R31](diffhunk://#diff-081c89c825cb88fdc987ad0b2532541f5198342c4206a32984b3852b70b25164L31-R31)).
* Assigned the `infrastructure-critical-priority` class to RabbitMQ (`infra/k8s/rabbitmq.yaml`, [infra/k8s/rabbitmq.yamlR42](diffhunk://#diff-72756ab151c73a23b341839f6bc29d0e5dcbc7ee7414d35f631074729dae7b3fR42)).
* Assigned the `infrastructure-critical-priority` class to Redis (`infra/k8s/redis.yaml`, [infra/k8s/redis.yamlR16](diffhunk://#diff-341c19fde9a486ee3138ca77ca40db6b9b93ddb79f3b998152a3290c8feb4a3aR16)).