### PR TITLE
Add Service Connector database secret with environment-specific manag…

### DIFF
--- a/infra/k8s/base/kustomization.yaml
+++ b/infra/k8s/base/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 
   # Secrets & Configuration
   - db-secret.yaml
+  - sc-azuredocsdbconnection-secret.yaml
   - secret-provider-class.yaml
   - redis-config.yaml
 

--- a/infra/k8s/base/sc-azuredocsdbconnection-secret.yaml
+++ b/infra/k8s/base/sc-azuredocsdbconnection-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sc-azuredocsdbconnection-secret
+  namespace: azuredocs-app
+type: Opaque
+stringData:
+  AZURE_POSTGRESQL_CLIENTID: "PLACEHOLDER"
+  AZURE_POSTGRESQL_CONNECTIONSTRING: "dbname=azuredocs host=linuxfirstdocs-db.postgres.database.azure.com port=5432 sslmode=require user=aad_azuredocs_db_connection"

--- a/infra/k8s/overlays/dev/kustomization.yaml
+++ b/infra/k8s/overlays/dev/kustomization.yaml
@@ -8,6 +8,7 @@ labels:
 patches:
   - path: service-account-patch.yaml
   - path: secret-provider-class-patch.yaml
+  - path: sc-azuredocsdbconnection-secret-patch.yaml
   - path: ingress-patch.yaml
     target:
       kind: Ingress

--- a/infra/k8s/overlays/dev/sc-azuredocsdbconnection-secret-patch.yaml
+++ b/infra/k8s/overlays/dev/sc-azuredocsdbconnection-secret-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sc-azuredocsdbconnection-secret
+  namespace: azuredocs-app
+type: Opaque
+stringData:
+  AZURE_POSTGRESQL_CLIENTID: "a1e3977e-3def-4e89-97a0-a4c5dcf9158b"

--- a/infra/k8s/overlays/prod/kustomization.yaml
+++ b/infra/k8s/overlays/prod/kustomization.yaml
@@ -8,6 +8,7 @@ labels:
 patches:
   - path: service-account-patch.yaml
   - path: secret-provider-class-patch.yaml
+  - path: sc-azuredocsdbconnection-secret-patch.yaml
 
 # configMapGenerator:
 #   - name: env-config

--- a/infra/k8s/overlays/prod/sc-azuredocsdbconnection-secret-patch.yaml
+++ b/infra/k8s/overlays/prod/sc-azuredocsdbconnection-secret-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sc-azuredocsdbconnection-secret
+  namespace: azuredocs-app
+type: Opaque
+stringData:
+  AZURE_POSTGRESQL_CLIENTID: "598c9c7b-cf9d-4b5b-9a00-988d9e13e16b"


### PR DESCRIPTION
…ed identities

This change adds the sc-azuredocsdbconnection-secret to provide PostgreSQL connection information using Azure Workload Identity for authentication. The secret contains the connection string and is patched per environment with the appropriate managed identity client ID.

Changes:
- Add base sc-azuredocsdbconnection-secret with connection string
- Add dev overlay patch with dev-specific managed identity client ID
- Add prod overlay patch with prod-specific managed identity client ID
- Update kustomization files to include new secret and patches

This resolves pod startup issues where the webui and worker pods were unable to start due to missing database connection configuration.