### PR TITLE
Update ClusterIssuer to use ingressClassName for cert-manager v1.19+

### DIFF
--- a/infra/k8s/base/cert-manager.yaml
+++ b/infra/k8s/base/cert-manager.yaml
@@ -19,7 +19,7 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: webapprouting.kubernetes.azure.com
+          ingressClassName: webapprouting.kubernetes.azure.com
 ---
 # Let's Encrypt ClusterIssuer for staging (testing)
 apiVersion: cert-manager.io/v1
@@ -39,4 +39,4 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: webapprouting.kubernetes.azure.com
+          ingressClassName: webapprouting.kubernetes.azure.com


### PR DESCRIPTION
The 'class' field is deprecated in favor of 'ingressClassName' in newer versions of cert-manager. This change ensures solver ingresses are created with the proper spec.ingressClassName field instead of using the deprecated kubernetes.io/ingress.class annotation.

This resolves HTTP-01 challenge failures where solver ingresses were not being properly routed by the App Routing addon.