### PR TITLE
Migrate database authentication from managed identity to Azure Worklo…

### DIFF
--- a/infra/k8s/overlays/dev/sc-azuredocsdbconnection-secret-patch.yaml
+++ b/infra/k8s/overlays/dev/sc-azuredocsdbconnection-secret-patch.yaml
@@ -6,3 +6,4 @@ metadata:
 type: Opaque
 stringData:
   AZURE_POSTGRESQL_CLIENTID: "a1e3977e-3def-4e89-97a0-a4c5dcf9158b"
+  AZURE_POSTGRESQL_CONNECTIONSTRING: "dbname=azuredocs host=linuxfirstdocs-pgsql.postgres.database.azure.com port=5432 sslmode=require user=aad_azuredocs_db_connection"


### PR DESCRIPTION
…ad Identity

Updates the database migration script to use Azure Workload Identity instead of IMDS-based managed identity authentication, and adds the database connection string to the Service Connector secret configuration for the dev environment.