### PR TITLE
Fix db-migrations build: align image name and context

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,9 +35,9 @@ jobs:
             test_deployment: infra/k8s/overlays/test/bias-scoring-deployment.yaml
 
           - service: db-migrations
-            context: ./infra/db
+            context: .
             dockerfile: ./infra/db/Dockerfile
-            test_deployment: infra/k8s/overlays/test/db-migrations-job.yaml
+            test_deployment: infra/k8s/base/db-migrate.yaml
 
     permissions:
       id-token: write

--- a/infra/k8s/base/db-migrate.yaml
+++ b/infra/k8s/base/db-migrate.yaml
@@ -12,7 +12,7 @@ spec:
       serviceAccountName: azuredocs-app-sa
       containers:
       - name: migrate
-        image: seanmckdemo.azurecr.io/db-migrate:0.0.51
+        image: seanmckdemo.azurecr.io/linuxfirst-azuredocs-db-migrations:main-0000000
         command: ["/bin/sh", "-c"]
         args: ["cd /app/infra/db && ./migrate.sh"]
         envFrom:


### PR DESCRIPTION
- Update manifest to use linuxfirst-azuredocs-db-migrations image name (matches what the workflow builds)
- Change workflow context to repo root so Dockerfile can copy shared/
- Point test_deployment to the correct manifest path