### PR TITLE
Fix Azure OpenAI deployment name for dev environment

### DIFF
--- a/infra/k8s/overlays/dev/kustomization.yaml
+++ b/infra/k8s/overlays/dev/kustomization.yaml
@@ -13,6 +13,7 @@ patches:
     target:
       kind: Ingress
       name: webui-ingress
+  - path: openai-deployment-patch.yaml
 
 # configMapGenerator:
 #   - name: env-config

--- a/infra/k8s/overlays/dev/openai-deployment-patch.yaml
+++ b/infra/k8s/overlays/dev/openai-deployment-patch.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scan-worker
+  namespace: azuredocs-app
+spec:
+  template:
+    spec:
+      containers:
+        - name: scan-worker
+          env:
+            - name: AZURE_OPENAI_DEPLOYMENT
+              value: "gpt-4"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: doc-worker
+  namespace: azuredocs-app
+spec:
+  template:
+    spec:
+      containers:
+        - name: doc-worker
+          env:
+            - name: AZURE_OPENAI_DEPLOYMENT
+              value: "gpt-4"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webui
+  namespace: azuredocs-app
+spec:
+  template:
+    spec:
+      containers:
+        - name: webui
+          env:
+            - name: AZURE_OPENAI_DEPLOYMENT
+              value: "gpt-4"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bias-scoring-service
+  namespace: azuredocs-app
+spec:
+  template:
+    spec:
+      containers:
+        - name: bias-scoring-service
+          env:
+            - name: AZURE_OPENAI_DEPLOYMENT
+              value: "gpt-4"


### PR DESCRIPTION
## Summary
- Dev environment uses `gpt-4` deployment while prod uses `gpt-4.1`
- Added Kustomize overlay patch for dev to set the correct deployment name
- Patches scan-worker, doc-worker, webui, and bias-scoring-service deployments

## Test plan
- [ ] Verify kustomize build succeeds for dev overlay
- [ ] After merge, verify ArgoCD syncs and deployments restart with correct env var
- [ ] Run a test scan and confirm no OpenAI deployment errors in logs