### PR TITLE
Add workload identity config to bias-scoring-service

### DIFF
--- a/infra/k8s/base/bias-scoring-service-keda.yaml
+++ b/infra/k8s/base/bias-scoring-service-keda.yaml
@@ -27,7 +27,9 @@ spec:
     metadata:
       labels:
         app: bias-scoring-service
+        azure.workload.identity/use: "true"
     spec:
+      serviceAccountName: azuredocs-app-sa
       priorityClassName: service-critical-priority
       containers:
         - name: bias-scoring-service


### PR DESCRIPTION
The bias-scoring-service was missing the serviceAccountName and workload identity label, causing it to fail Azure OpenAI authentication via IMDS instead of using federated tokens.