### PR TITLE
Fix Docker build context to use repo root

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,19 +20,22 @@ jobs:
           # EDIT THESE FOR YOUR REPO
           # -------------------------------
           - service: web
-            context: ./services/web
+            context: .
             dockerfile: ./services/web/Dockerfile
             test_deployment: infra/k8s/overlays/test/web-deployment.yaml
+            change_path: ./services/web
 
           - service: worker
-            context: ./services/worker
+            context: .
             dockerfile: ./services/worker/Dockerfile
             test_deployment: infra/k8s/overlays/test/worker-deployment.yaml
+            change_path: ./services/worker
 
           - service: bias-scoring-service
-            context: ./services/bias-scoring-service
+            context: .
             dockerfile: ./services/bias-scoring-service/Dockerfile
             test_deployment: infra/k8s/overlays/test/bias-scoring-deployment.yaml
+            change_path: ./services/bias-scoring-service
 
           - service: db-migrations
             context: .


### PR DESCRIPTION
All Dockerfiles use paths relative to repo root (e.g., COPY shared, COPY packages), so context must be "." not service subdirectories. Added change_path to maintain correct change detection.