### PR TITLE
Remove replicas from doc-worker to let KEDA manage scaling

### DIFF
--- a/infra/k8s/base/doc-worker-keda.yaml
+++ b/infra/k8s/base/doc-worker-keda.yaml
@@ -7,7 +7,7 @@ metadata:
     app: doc-worker
     component: worker
 spec:
-  replicas: 1
+  # replicas managed by KEDA ScaledObject
   selector:
     matchLabels:
       app: doc-worker


### PR DESCRIPTION
KEDA ScaledObject sets minReplicaCount: 0, which caused ArgoCD to show the deployment as out-of-sync when scaled down. Removing the explicit replicas field lets KEDA be the sole owner of replica count.