### PR TITLE
Update cronjob images to main-43f9af4

### DIFF
--- a/infra/k8s/base/bias-snapshot-cronjob.yaml
+++ b/infra/k8s/base/bias-snapshot-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: bias-snapshot-generator
-            image: seanmckdemo.azurecr.io/queue-worker:0.0.56
+            image: seanmckdemo.azurecr.io/queue-worker:main-43f9af4
             imagePullPolicy: Always
             command: ["python", "/app/scripts/update_bias_snapshots.py"]
             env:

--- a/infra/k8s/base/doc-collector-cronjob.yaml
+++ b/infra/k8s/base/doc-collector-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: doc-collector
-            image: seanmckdemo.azurecr.io/queue-worker:0.0.56
+            image: seanmckdemo.azurecr.io/queue-worker:main-43f9af4
             imagePullPolicy: Always
             command: ["python", "/app/scripts/enqueue_github_scan.py"]
             env:

--- a/infra/k8s/base/scan-worker.yaml
+++ b/infra/k8s/base/scan-worker.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: azuredocs-app-sa
       containers:
       - name: scan-worker
-        image: seanmckdemo.azurecr.io/queue-worker:0.0.56
+        image: seanmckdemo.azurecr.io/queue-worker:main-43f9af4
         imagePullPolicy: Always
         command: ["python", "worker/queue_worker.py"]
         env:


### PR DESCRIPTION
Updates doc-collector and bias-snapshot cronjobs to use the latest worker image with new repos config.