### PR TITLE
Fix workflow to update all manifests using same image

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -131,9 +131,10 @@ jobs:
         run: |
           IMAGE="${{ steps.meta.outputs.image }}"
           IMAGE_NAME="${{ steps.meta.outputs.image_name }}"
-          DEPLOYMENT="${{ matrix.test_deployment }}"
 
-          sed -i "s|image: .*/${IMAGE_NAME}:.*|image: ${IMAGE}|" "${DEPLOYMENT}"
+          # Update all manifests that use this image
+          find infra/k8s -name "*.yaml" -exec grep -l "/${IMAGE_NAME}:" {} \; | \
+            xargs -r sed -i "s|image: .*/${IMAGE_NAME}:.*|image: ${IMAGE}|"
 
           if git diff --quiet; then
             exit 0


### PR DESCRIPTION
Uses find+sed to update all k8s manifests that reference the image, including cronjobs