### PR TITLE
ci: only run build workflow on main branch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,7 +3,7 @@ name: Build Changed Services & Update Test
 on:
   push:
     branches:
-      - '**'
+      - main
   workflow_dispatch:
     inputs:
       force_build:


### PR DESCRIPTION
Feature branches can't authenticate to Azure OIDC anyway, so running the workflow just produces noise. Keep workflow_dispatch for manual runs.