### PR TITLE
feat: add batch snippet scoring to reduce API calls by 5-10x

### DIFF
--- a/shared/config.py
+++ b/shared/config.py
@@ -127,7 +127,9 @@ class AzureOpenAIConfig:
     deployment: str = "gpt-35-turbo"
     api_version: str = "2023-05-15"
     client_id: Optional[str] = None  # For managed identity authentication
-    
+    requests_per_minute: int = 60  # Rate limit for API requests
+    llm_batch_size: int = 5  # Number of snippets to score per LLM request (1 = no batching)
+
     @classmethod
     def from_env(cls) -> 'AzureOpenAIConfig':
         return cls(
@@ -135,7 +137,9 @@ class AzureOpenAIConfig:
             endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
             deployment=os.getenv("AZURE_OPENAI_DEPLOYMENT", "gpt-35-turbo"),
             api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2023-05-15"),
-            client_id=os.getenv("AZURE_OPENAI_CLIENTID")
+            client_id=os.getenv("AZURE_OPENAI_CLIENTID"),
+            requests_per_minute=int(os.getenv("AZURE_OPENAI_RPM", "60")),
+            llm_batch_size=int(os.getenv("LLM_BATCH_SIZE", "5"))
         )
     
     @property


### PR DESCRIPTION
- Add /score_snippets endpoint to bias-scoring-service for batch LLM calls
- Update scoring_service.py to batch snippets (default: 5 per request)
- Add LLM_BATCH_SIZE config (env var, default 5, set to 1 to disable)
- Includes automatic fallback to individual scoring on batch failure

This significantly improves efficiency for rate-limited Azure OpenAI tiers by scoring multiple snippets per API call instead of one at a time.