### PR TITLE
chore: increase KEDA max workers to 6 after batch scoring optimization

### DIFF
--- a/infra/k8s/base/doc-worker-keda.yaml
+++ b/infra/k8s/base/doc-worker-keda.yaml
@@ -123,7 +123,7 @@ spec:
   scaleTargetRef:
     name: doc-worker
   minReplicaCount: 0
-  maxReplicaCount: 3
+  maxReplicaCount: 6
   cooldownPeriod: 300
   triggers:
   - type: rabbitmq


### PR DESCRIPTION
Batch scoring reduces API calls by 5x, so we can safely increase max workers from 3 to 6 while staying within rate limits.