### PR TITLE
feat: optimize LLM costs with unified page-level scoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,12 @@ A microservices-based Python application that scans Azure documentation reposito
 
 ### Local Development
 ```bash
-./setup_and_run.sh --web          # Setup venv and run web UI locally
-./setup_and_run.sh --docker       # Run all services in Docker
-./setup_and_run.sh --wipe --web   # Reset everything and start fresh
+./scripts/start-dev.sh            # Setup venv, start infra (db, rabbitmq), run all services
+```
+
+**Note:** When running services manually (not via start-dev.sh), set PYTHONPATH first:
+```bash
+export PYTHONPATH=$(pwd):$PYTHONPATH
 ```
 
 ### Running Individual Services
@@ -74,9 +77,16 @@ Routes are in `services/web/src/routes/`:
 - `scan.py`: Scan management
 - `llm.py`: LLM scoring endpoints
 - `docpage.py`: Document page display
+- `docset.py`: Documentation set queries
 - `auth.py`: GitHub OAuth authentication
 - `feedback.py`: User feedback collection
 - `websocket.py`: Real-time scan progress
+
+### Service Ports
+- **Web UI**: 8000 (local), 8010 (Docker host → 8000 container)
+- **Bias Scoring**: 9000
+- **PostgreSQL**: 5432
+- **RabbitMQ**: 5672 (AMQP), 15672 (management UI)
 
 ## Key Environment Variables
 
@@ -89,6 +99,8 @@ AZURE_OPENAI_KEY=your-key
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
 AZURE_OPENAI_DEPLOYMENT=gpt-35-turbo
 AZURE_OPENAI_CLIENTID=client-id  # For managed identity (alternative to API key)
+AZURE_OPENAI_RPM=60               # Rate limit requests per minute
+LLM_BATCH_SIZE=5                  # Snippets per LLM request
 
 # RabbitMQ
 RABBITMQ_HOST=localhost

--- a/packages/scorer/heuristics.py
+++ b/packages/scorer/heuristics.py
@@ -1,7 +1,53 @@
 # heuristics.py
-# Optional: Lightweight regex-based pre-filtering of extracted snippets.
+# Lightweight regex-based pre-filtering for Windows bias detection.
+# Used for both snippet-level and page-level heuristic scanning.
 
 import re
+
+
+# Patterns to detect Windows-specific content in full page prose/code
+PROSE_WINDOWS_PATTERNS = [
+    r'\bPowerShell\b',
+    r'\bFiddler\b',
+    r'\.exe\b',
+    r'\badministrator\b',
+    r'\.NET Framework\b',
+    r'\bWindows Server\b',
+    r'\bIIS\b',
+    r'\bwin2019',   # Matches win2019, win2019datacenter, etc.
+    r'\bwin2022',   # Matches win2022, win2022datacenter, etc.
+    r'\bwin2016',   # Matches win2016, win2016datacenter, etc.
+    r'Windows-only',
+    r'Windows VM',
+    r'\bwinget\b',
+    r'\bchoco\b',
+    r'chocolatey',
+    r'msiexec',
+    r'regedit',
+    r'Windows Registry',
+]
+
+
+def page_has_windows_signals(page_content: str) -> bool:
+    """
+    Check if a page has Windows-specific content that needs LLM review.
+
+    Used as a pre-filter to skip LLM scoring for pages with no Windows signals,
+    reducing costs while ensuring Windows-biased pages get full analysis.
+
+    Args:
+        page_content: Full markdown/text content of the page
+
+    Returns:
+        True if Windows signals detected, False otherwise
+    """
+    if not page_content:
+        return False
+
+    for pattern in PROSE_WINDOWS_PATTERNS:
+        if re.search(pattern, page_content, re.IGNORECASE):
+            return True
+    return False
 
 def is_windows_biased(snippet):
     # If the snippet is under an Azure PowerShell tab, do not flag as biased

--- a/services/web/src/templates/docset_details.html
+++ b/services/web/src/templates/docset_details.html
@@ -232,6 +232,29 @@
             margin: 0;
             padding: 0;
         }
+
+        /* Review method badges */
+        .review-badge {
+            display: inline-flex;
+            align-items: center;
+            padding: 0.2em 0.5em;
+            border-radius: 4px;
+            font-size: 0.75em;
+            font-weight: 600;
+            margin-left: 0.5em;
+        }
+
+        .review-badge.review-llm {
+            background: rgba(37, 99, 235, 0.1);
+            color: #2563eb;
+            border: 1px solid rgba(37, 99, 235, 0.2);
+        }
+
+        .review-badge.review-heuristic {
+            background: rgba(107, 114, 128, 0.1);
+            color: #6b7280;
+            border: 1px solid rgba(107, 114, 128, 0.2);
+        }
     </style>
 </head>
 <body>
@@ -361,6 +384,11 @@
                                 Scanned: {{ page.scan_date.strftime('%Y-%m-%d %H:%M') }}
                                 {% if page.bias_details.mcp_holistic %}
                                      • Page-level bias detected
+                                {% endif %}
+                                {% if page.bias_details.mcp_holistic and page.bias_details.mcp_holistic.get('review_method') == 'llm' %}
+                                    <span class="review-badge review-llm">LLM Reviewed</span>
+                                {% elif page.bias_details.mcp_holistic and page.bias_details.mcp_holistic.get('review_method') == 'heuristic_skip' %}
+                                    <span class="review-badge review-heuristic">Heuristic Skip</span>
                                 {% endif %}
                             </div>
                         </div>

--- a/services/web/src/templates/scan_details_partial.html
+++ b/services/web/src/templates/scan_details_partial.html
@@ -321,6 +321,47 @@
         grid-template-columns: 1fr;
     }
 }
+
+/* Review method badges */
+.page-badges {
+    display: flex;
+    gap: 0.5em;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.review-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.3em 0.7em;
+    border-radius: 6px;
+    font-size: 0.8em;
+    font-weight: 600;
+}
+
+.review-badge.review-llm {
+    background: rgba(37, 99, 235, 0.1);
+    color: #2563eb;
+    border: 1px solid rgba(37, 99, 235, 0.2);
+}
+
+.review-badge.review-heuristic {
+    background: rgba(107, 114, 128, 0.1);
+    color: #6b7280;
+    border: 1px solid rgba(107, 114, 128, 0.2);
+}
+
+.review-badge.review-error {
+    background: rgba(239, 68, 68, 0.1);
+    color: #dc2626;
+    border: 1px solid rgba(239, 68, 68, 0.2);
+}
+
+.review-badge.review-unknown {
+    background: rgba(234, 179, 8, 0.1);
+    color: #ca8a04;
+    border: 1px solid rgba(234, 179, 8, 0.2);
+}
 </style>
 
 <!-- Problematic Pages (Holistic MCP) -->
@@ -337,8 +378,18 @@
                             <a href="{{ page.url }}" target="_blank" rel="noopener noreferrer">{{ page.url }}</a>
                             <a href="/docpage/{{ page.id }}" style="margin-left: 0.5em; color: #2563eb; text-decoration: none; font-size: 0.9em;">[View Details]</a>
                         </div>
-                        
-                        <span class="priority-badge priority-{{ page['priority_label']|lower }}">{{ page['priority_label'] }} Priority</span>
+                        <div class="page-badges">
+                            {% if page.mcp_holistic and page.mcp_holistic.get('review_method') == 'llm' %}
+                                <span class="review-badge review-llm">LLM Reviewed</span>
+                            {% elif page.mcp_holistic and page.mcp_holistic.get('review_method') == 'heuristic_skip' %}
+                                <span class="review-badge review-heuristic">Heuristic Skip</span>
+                            {% elif page.mcp_holistic and page.mcp_holistic.get('review_method') == 'llm_error' %}
+                                <span class="review-badge review-error">LLM Error</span>
+                            {% else %}
+                                <span class="review-badge review-unknown">Not Scored</span>
+                            {% endif %}
+                            <span class="priority-badge priority-{{ page['priority_label']|lower }}">{{ page['priority_label'] }} Priority</span>
+                        </div>
                     </div>
                     <div class="analysis-content">
                         <div class="snippet-label">Bias Types:</div>


### PR DESCRIPTION
## Summary

- Implement heuristic pre-filter to skip LLM review for pages without Windows signals
- Replace dual LLM scoring (snippets + holistic) with unified page-level flow
- Use heuristic fallback instead of individual LLM calls on batch timeout
- Add review method badges to UI showing how each page was scored

## Changes

### Unified Scoring Flow
Pages are now filtered by regex-based heuristics before LLM review:
- **Windows signals detected** → send to LLM for holistic review
- **No Windows signals** → skip LLM entirely, mark as `heuristic_skip`

### Heuristic Patterns
Added `page_has_windows_signals()` function detecting:
- PowerShell, Fiddler, IIS, Windows Server
- win2019/win2022/win2016 (and variants like win2019datacenter)
- .exe files, winget, chocolatey, msiexec, regedit
- Windows Registry references

### UI Improvements
- Added review method badges: "LLM Reviewed", "Heuristic Skip", "LLM Error", "Not Scored"
- Badges appear on scan details and docset details pages

## Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| LLM calls per page | 2 (snippets + holistic) | 0 or 1 |
| Pages sent to LLM | ~100% | ~30% |
| Estimated token reduction | - | ~80% |

## Test plan

- [ ] Run scan on sample pages and verify heuristic filter catches Windows pages
- [ ] Verify clean pages (pure Azure CLI) are skipped
- [ ] Check UI shows correct review method badges
- [ ] Measure token usage before/after