### PR TITLE
feat: decouple heuristic checks from LLM scoring with two-queue archi…

### DIFF
--- a/infra/k8s/base/kustomization.yaml
+++ b/infra/k8s/base/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
   - webui.yaml
   - scan-worker.yaml
   - doc-worker-keda.yaml
+  - llm-worker-keda.yaml
   - bias-scoring-service-keda.yaml
 
   # Jobs & CronJobs

--- a/infra/k8s/base/llm-worker-keda.yaml
+++ b/infra/k8s/base/llm-worker-keda.yaml
@@ -1,0 +1,136 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-worker
+  namespace: azuredocs-app
+  labels:
+    app: llm-worker
+    component: worker
+spec:
+  # replicas managed by KEDA ScaledObject
+  selector:
+    matchLabels:
+      app: llm-worker
+  template:
+    metadata:
+      labels:
+        app: llm-worker
+        component: worker
+        azure.workload.identity/use: "true"
+    spec:
+      priorityClassName: worker-normal-priority
+      serviceAccountName: azuredocs-app-sa
+      terminationGracePeriodSeconds: 120  # Longer for LLM calls
+      containers:
+      - name: llm-worker
+        image: seanmckdemo.azurecr.io/queue-worker:main-bab875f
+        imagePullPolicy: Always
+        command: ["python", "worker/llm_scoring_worker.py"]
+        env:
+        - name: ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: azuredocs-secrets
+              key: ADMIN_PASSWORD
+        - name: ADMIN_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: azuredocs-secrets
+              key: ADMIN_USERNAME
+        - name: APP_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: azuredocs-secrets
+              key: APP_SECRET_KEY
+        - name: PYTHONPATH
+          value: "/app"
+        - name: RABBITMQ_HOST
+          value: "rabbitmq"
+        - name: RABBITMQ_PORT
+          value: "5672"
+        - name: RABBITMQ_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: azuredocs-secrets
+              key: RABBITMQ_USERNAME
+        - name: RABBITMQ_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: azuredocs-secrets
+              key: RABBITMQ_PASSWORD
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: azuredocs-secrets
+              key: GITHUB_TOKEN
+        - name: AZURE_OPENAI_DEPLOYMENT
+          value: "gpt-4.1"
+        - name: MCP_SERVER_URL
+          value: "http://bias-scoring-service:9000/score_page"
+        envFrom:
+        - secretRef:
+            name: sc-azuredocsdbconnection-secret
+        - secretRef:
+            name: sc-linuxdocsazureopenai-secret
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        livenessProbe:
+          exec:
+            command:
+            - python
+            - -c
+            - "import sys; sys.exit(0)"
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          exec:
+            command:
+            - python
+            - -c
+            - "import sys; sys.exit(0)"
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        volumeMounts:
+        - name: secrets-store
+          mountPath: "/mnt/secrets-store"
+          readOnly: true
+      volumes:
+      - name: secrets-store
+        csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: "azuredocs-secrets"
+      restartPolicy: Always
+      nodeSelector:
+        karpenter.sh/capacity-type: spot
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: llm-worker-scaler
+  namespace: azuredocs-app
+spec:
+  scaleTargetRef:
+    name: llm-worker
+  minReplicaCount: 0
+  maxReplicaCount: 2  # Limited by LLM rate limit
+  cooldownPeriod: 300
+  triggers:
+  - type: rabbitmq
+    metadata:
+      queueName: llm_scoring
+      mode: QueueLength
+      value: "5"  # Scale up when queue has 5+ messages
+      excludeUnacknowledged: "false"
+    authenticationRef:
+      name: rabbitmq-trigger-auth

--- a/services/web/src/templates/docset_details.html
+++ b/services/web/src/templates/docset_details.html
@@ -387,6 +387,8 @@
                                 {% endif %}
                                 {% if page.bias_details.mcp_holistic and page.bias_details.mcp_holistic.get('review_method') == 'llm' %}
                                     <span class="review-badge review-llm">LLM Reviewed</span>
+                                {% elif page.bias_details.mcp_holistic and page.bias_details.mcp_holistic.get('review_method') == 'llm_pending' %}
+                                    <span class="review-badge review-pending">LLM Pending</span>
                                 {% elif page.bias_details.mcp_holistic and page.bias_details.mcp_holistic.get('review_method') == 'heuristic_skip' %}
                                     <span class="review-badge review-heuristic">Heuristic Skip</span>
                                 {% endif %}

--- a/services/web/src/templates/scan_details_partial.html
+++ b/services/web/src/templates/scan_details_partial.html
@@ -357,6 +357,12 @@
     border: 1px solid rgba(239, 68, 68, 0.2);
 }
 
+.review-badge.review-pending {
+    background: rgba(168, 85, 247, 0.1);
+    color: #9333ea;
+    border: 1px solid rgba(168, 85, 247, 0.2);
+}
+
 .review-badge.review-unknown {
     background: rgba(234, 179, 8, 0.1);
     color: #ca8a04;
@@ -381,6 +387,8 @@
                         <div class="page-badges">
                             {% if page.mcp_holistic and page.mcp_holistic.get('review_method') == 'llm' %}
                                 <span class="review-badge review-llm">LLM Reviewed</span>
+                            {% elif page.mcp_holistic and page.mcp_holistic.get('review_method') == 'llm_pending' %}
+                                <span class="review-badge review-pending">LLM Pending</span>
                             {% elif page.mcp_holistic and page.mcp_holistic.get('review_method') == 'heuristic_skip' %}
                                 <span class="review-badge review-heuristic">Heuristic Skip</span>
                             {% elif page.mcp_holistic and page.mcp_holistic.get('review_method') == 'llm_error' %}

--- a/services/worker/src/llm_scoring_worker.py
+++ b/services/worker/src/llm_scoring_worker.py
@@ -1,0 +1,160 @@
+"""
+LLMScoringWorker - Handles LLM scoring tasks from the llm_scoring queue
+This worker is decoupled from the document worker to allow heuristic checks
+to run at full speed while LLM calls run at rate-limited speed.
+"""
+import sys
+import os
+import time
+import signal
+import threading
+from typing import Dict, Any
+
+# Add the project root to the Python path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..'))
+sys.path.insert(0, project_root)
+
+from shared.models import Page, Scan
+from shared.infrastructure.queue_service import QueueService
+from shared.application.progress_tracker import progress_tracker
+from shared.utils.database import SessionLocal
+from shared.utils.logging import get_logger
+from shared.utils.metrics import get_metrics
+from scoring_service import ScoringService
+
+
+class LLMScoringWorker:
+    """Worker that processes LLM scoring tasks from the llm_scoring queue"""
+
+    def __init__(self):
+        self.queue_service = QueueService(queue_name='llm_scoring')
+        self.scoring_service = ScoringService()
+        self.logger = get_logger(__name__)
+        self.metrics = get_metrics()
+        self.worker_id = f"llm_scoring_worker_{os.getpid()}_{int(time.time())}"
+        self.shutdown_event = threading.Event()
+        self.setup_signal_handlers()
+
+    def setup_signal_handlers(self):
+        """Setup signal handlers for graceful shutdown"""
+        def signal_handler(signum, frame):
+            self.logger.info(f"Received signal {signum}, initiating graceful shutdown...")
+            self.shutdown_event.set()
+
+        signal.signal(signal.SIGTERM, signal_handler)
+        signal.signal(signal.SIGINT, signal_handler)
+
+    def process_llm_task(self, message: Dict[str, Any]) -> bool:
+        """
+        Process a single LLM scoring task from the queue
+
+        Args:
+            message: LLM scoring message with scan_id, page_id, page_url, page_content
+
+        Returns:
+            True if successful, False otherwise
+        """
+        scan_id = message.get('scan_id')
+        page_id = message.get('page_id')
+        page_url = message.get('page_url')
+        page_content = message.get('page_content')
+
+        if not all([scan_id, page_id, page_url, page_content]):
+            self.logger.error(f"Invalid LLM scoring message: missing required fields")
+            return True  # Ack bad message to avoid infinite retry
+
+        self.logger.info(f"Processing LLM scoring task: page_id={page_id}, url={page_url[:80]}...")
+
+        processing_start_time = time.time()
+        db_session = SessionLocal()
+
+        try:
+            # Check if scan was cancelled
+            scan = db_session.query(Scan).filter(Scan.id == scan_id).first()
+            if scan and scan.cancellation_requested:
+                self.logger.info(f"Scan {scan_id} was cancelled, skipping LLM scoring for page {page_id}")
+                return True
+
+            # Get the page record
+            page = db_session.query(Page).filter(Page.id == page_id).first()
+            if not page:
+                self.logger.warning(f"Page {page_id} not found, may have been deleted")
+                return True  # Page deleted, skip
+
+            # Call the LLM for holistic scoring (this is the slow part, ~60 sec)
+            self.logger.info(f"[LLM] Calling MCP server for page {page_id}")
+            mcp_result = self.scoring_service.apply_mcp_holistic_scoring(
+                page_content, page_url
+            )
+
+            if mcp_result:
+                mcp_result['review_method'] = 'llm'
+                page.mcp_holistic = mcp_result
+                self.logger.info(f"[LLM] Successfully scored page {page_id}, bias_types={mcp_result.get('bias_types', [])}")
+
+                # Report bias if detected
+                if mcp_result.get('bias_types'):
+                    progress_tracker.report_page_result(
+                        db_session, scan_id, page_url, True, mcp_result
+                    )
+            else:
+                # LLM call failed
+                page.mcp_holistic = {
+                    'bias_types': [],
+                    'summary': None,
+                    'review_method': 'llm_error',
+                    'error': 'Holistic scoring failed'
+                }
+                self.logger.warning(f"[LLM] Failed to score page {page_id}")
+
+            db_session.commit()
+
+            # Record metrics
+            processing_time = time.time() - processing_start_time
+            self.metrics.record_file_change_processed('llm_scoring', 'success', processing_time)
+            self.logger.info(f"[LLM] Completed page {page_id} in {processing_time:.1f}s")
+
+            return True
+
+        except Exception as e:
+            self.logger.error(f"Error processing LLM scoring task for page {page_id}: {e}", exc_info=True)
+            self.metrics.record_file_change_processed('llm_scoring', 'error', time.time() - processing_start_time)
+            return False
+
+        finally:
+            db_session.close()
+
+    def start_consuming(self):
+        """Start consuming LLM scoring tasks from the queue"""
+        self.logger.info("LLM scoring worker starting...")
+
+        if not self.queue_service.connect():
+            self.logger.error("Failed to connect to RabbitMQ")
+            return
+
+        try:
+            self.logger.info("Starting to consume LLM scoring tasks...")
+            self.queue_service.consume_tasks(self.process_llm_task, shutdown_event=self.shutdown_event)
+
+        except Exception as e:
+            self.logger.error(f"Error during LLM scoring task consumption: {e}", exc_info=True)
+
+        finally:
+            self.logger.info("LLM scoring worker shutting down gracefully...")
+            self.queue_service.disconnect()
+
+
+def main():
+    """Main entry point for the LLM scoring worker"""
+    logger = get_logger(__name__)
+    try:
+        logger.info("Starting LLM scoring worker...")
+        worker = LLMScoringWorker()
+        worker.start_consuming()
+
+    except Exception as e:
+        logger.error(f"Fatal error in LLM scoring worker: {e}", exc_info=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
…tecture

This eliminates the 60-second blocking gap between file processing by:

- Creating new llm_scoring_worker.py to handle LLM calls asynchronously
- Modifying document_worker.py to publish to llm_scoring queue instead of blocking
- Adding llm-worker-keda.yaml for KEDA-managed LLM worker scaling (max 2 replicas)
- Updating scan finalization to wait for all LLM scoring to complete
- Adding llm_pending badge to UI templates

Before: Heuristic checks blocked on LLM calls (~1 page/min throughput) After: Heuristic checks blast through (~100+ pages/sec) while LLM calls
       run in parallel at rate limit