### PR TITLE
fix(prod): align image tags with current prod state

### DIFF
--- a/infra/k8s/overlays/prod/kustomization.yaml
+++ b/infra/k8s/overlays/prod/kustomization.yaml
@@ -1,22 +1,22 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base
+- ../../base
 labels:
-  - pairs:
-      environment: prod
+- pairs:
+    environment: prod
 patches:
-  - path: service-account-patch.yaml
-  - path: secret-provider-class-patch.yaml
-  - path: sc-azuredocsdbconnection-secret-patch.yaml
+- path: service-account-patch.yaml
+- path: secret-provider-class-patch.yaml
+- path: sc-azuredocsdbconnection-secret-patch.yaml
 
 # Image versions for prod environment (updated via promotion PR)
 images:
-  - name: seanmckdemo.azurecr.io/webui
-    newTag: main-f1b54ff
-  - name: seanmckdemo.azurecr.io/queue-worker
-    newTag: main-64a8f5f
-  - name: seanmckdemo.azurecr.io/bias-scoring-service
-    newTag: main-bab875f
-  - name: seanmckdemo.azurecr.io/linuxfirst-azuredocs-db-migrations
-    newTag: main-bab875f
+- name: seanmckdemo.azurecr.io/bias-scoring-service
+  newTag: main-bab875f
+- name: seanmckdemo.azurecr.io/linuxfirst-azuredocs-db-migrations
+  newTag: main-bab875f
+- name: seanmckdemo.azurecr.io/queue-worker
+  newTag: 0.0.56
+- name: seanmckdemo.azurecr.io/webui
+  newTag: 0.0.78


### PR DESCRIPTION
## Summary

Aligns prod overlay image tags with what's currently running in production before ArgoCD takes over.

| Image | Tag | Notes |
|-------|-----|-------|
| webui | 0.0.78 | Current prod |
| queue-worker | 0.0.56 | Current prod |
| bias-scoring-service | main-bab875f | New (replaces mcp-server) |
| db-migrations | main-bab875f | New |

## Why

ArgoCD prod app is showing OutOfSync because the image tags in Git didn't match live state. This aligns them so the first sync is safe.

## Next steps after merge

1. ArgoCD syncs prod (should be minimal changes for existing services)
2. Run database migrations manually
3. Promote dev images to prod via promotion PR