### PR TITLE
fix: add karpenter.sh/NodePool to AppProject allowlist

### DIFF
--- a/infra/argocd/projects/linuxfirst-docs.yaml
+++ b/infra/argocd/projects/linuxfirst-docs.yaml
@@ -22,6 +22,8 @@ spec:
       kind: ClusterRoleBinding
     - group: cert-manager.io
       kind: ClusterIssuer
+    - group: karpenter.sh
+      kind: NodePool
   # Namespace-scoped resources (only what we deploy)
   namespaceResourceWhitelist:
     # Core resources


### PR DESCRIPTION
Allows ArgoCD to manage the spot NodePool resource. Required for sync to succeed.