### PR TITLE
fix: remove PreSync hook from db-migrate job

### DIFF
--- a/infra/k8s/base/db-migrate.yaml
+++ b/infra/k8s/base/db-migrate.yaml
@@ -3,9 +3,9 @@ kind: Job
 metadata:
   name: db-migrate
   namespace: azuredocs-app
-  annotations:
-    argocd.argoproj.io/hook: PreSync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+  # Hook annotations removed - run migrations manually before promotions
+  # argocd.argoproj.io/hook: PreSync
+  # argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
   template:
     metadata:


### PR DESCRIPTION
Migrations should run manually before promotions, not automatically on every sync.