### PR TITLE
chore(prod): promote queue-worker and webui from dev

### DIFF
--- a/infra/k8s/overlays/prod/kustomization.yaml
+++ b/infra/k8s/overlays/prod/kustomization.yaml
@@ -17,6 +17,6 @@ images:
 - name: seanmckdemo.azurecr.io/linuxfirst-azuredocs-db-migrations
   newTag: main-bab875f
 - name: seanmckdemo.azurecr.io/queue-worker
-  newTag: 0.0.56
+  newTag: main-64a8f5f
 - name: seanmckdemo.azurecr.io/webui
-  newTag: 0.0.78
+  newTag: main-f1b54ff


### PR DESCRIPTION
## Summary
- Promotes queue-worker from `0.0.56` to `main-64a8f5f` (fixes llm-worker crash - missing `llm_scoring_worker.py`)
- Promotes webui from `0.0.78` to `main-f1b54ff`

## Context
After setting up ArgoCD GitOps, the db-migrate job was failing due to PostgreSQL AAD authentication OID mismatch. That's been fixed by updating the security label on the database role.

Now the llm-worker is crashing because the old `0.0.56` image doesn't have the `llm_scoring_worker.py` file.

## Test plan
- [ ] ArgoCD syncs successfully
- [ ] llm-worker pod starts without crash
- [ ] webui remains healthy