### PR TITLE
feat(argocd): enable auto-sync for prod application

### DIFF
--- a/infra/argocd/apps/prod-app.yaml
+++ b/infra/argocd/apps/prod-app.yaml
@@ -13,13 +13,8 @@ spec:
     server: https://kubernetes.default.svc
     namespace: azuredocs-app
   syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true
-  # No automated block initially - manual sync only
-  # Enable after successful cutover:
-  # syncPolicy:
-  #   automated:
-  #     prune: true
-  #     selfHeal: true
-  #   syncOptions:
-  #     - CreateNamespace=true


### PR DESCRIPTION
## Summary
- Enable automated sync policy for prod ArgoCD application
- Includes prune and selfHeal settings for automatic reconciliation
- Removes commented-out manual sync instructions after successful cutover

## Test plan
- [ ] Verify ArgoCD detects the config change
- [ ] Confirm prod app shows auto-sync enabled in ArgoCD UI
- [ ] Test that changes to main branch auto-deploy to prod