### PR TITLE
fix(rabbitmq): make queues durable to survive restarts

### DIFF
--- a/infra/k8s/base/rabbitmq.yaml
+++ b/infra/k8s/base/rabbitmq.yaml
@@ -6,6 +6,15 @@ metadata:
 data:
   rabbitmq.conf: |
     loopback_users = none
+    load_definitions = /etc/rabbitmq/definitions.json
+  definitions.json: |
+    {
+      "queues": [
+        {"name": "scan_tasks", "vhost": "/", "durable": true, "auto_delete": false, "arguments": {}},
+        {"name": "changed_files", "vhost": "/", "durable": true, "auto_delete": false, "arguments": {}},
+        {"name": "llm_scoring", "vhost": "/", "durable": true, "auto_delete": false, "arguments": {}}
+      ]
+    }
 ---
 apiVersion: v1
 kind: Service

--- a/scripts/enqueue_github_scan.py
+++ b/scripts/enqueue_github_scan.py
@@ -32,7 +32,7 @@ def enqueue_scan_task(url, scan_id, source, force_rescan=False):
         credentials=credentials
     ))
     channel = connection.channel()
-    channel.queue_declare(queue='scan_tasks')
+    channel.queue_declare(queue='scan_tasks', durable=True)
     
     task_data = {
         "url": url,

--- a/services/web/src/routes/scan.py
+++ b/services/web/src/routes/scan.py
@@ -198,7 +198,7 @@ def enqueue_scan_task(url, scan_id, source, force_rescan=False):
         credentials=credentials
     ))
     channel = connection.channel()
-    channel.queue_declare(queue='scan_tasks')
+    channel.queue_declare(queue='scan_tasks', durable=True)
     task_data = {
         "url": url,
         "scan_id": scan_id,

--- a/shared/infrastructure/queue_service.py
+++ b/shared/infrastructure/queue_service.py
@@ -57,7 +57,7 @@ class QueueService:
                 self.channel.basic_qos(prefetch_count=1)
                 self.logger.debug("Set prefetch_count=1 for proper KEDA scaling")
                 
-                self.channel.queue_declare(queue=self.queue_name)
+                self.channel.queue_declare(queue=self.queue_name, durable=True)
                 self.logger.debug(f"Queue '{self.queue_name}' declared.")
                 
                 # Log current queue state


### PR DESCRIPTION
KEDA couldn't scale workers when RabbitMQ restarted because non-durable queues were lost. This caused a deadlock: no queues → KEDA can't monitor → no workers scaled up → no one to recreate queues.

Changes:
- Add definitions.json to pre-create durable queues on RabbitMQ startup
- Update queue declarations to use durable=True for consistency

Deployment note: Restart RabbitMQ before deploying new worker images to avoid PRECONDITION_FAILED errors from queue property mismatch.