### PR TITLE
fix(rabbitmq): remove definitions.json that broke user auth

### DIFF
--- a/infra/k8s/base/rabbitmq.yaml
+++ b/infra/k8s/base/rabbitmq.yaml
@@ -6,18 +6,6 @@ metadata:
 data:
   rabbitmq.conf: |
     loopback_users = none
-    load_definitions = /etc/rabbitmq/definitions.json
-  definitions.json: |
-    {
-      "vhosts": [
-        {"name": "/"}
-      ],
-      "queues": [
-        {"name": "scan_tasks", "vhost": "/", "durable": true, "auto_delete": false, "arguments": {}},
-        {"name": "changed_files", "vhost": "/", "durable": true, "auto_delete": false, "arguments": {}},
-        {"name": "llm_scoring", "vhost": "/", "durable": true, "auto_delete": false, "arguments": {}}
-      ]
-    }
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The load_definitions feature expects complete config including users. Rely on code to create durable queues instead.