### PR TITLE
chore(prod): promote queue-worker and webui from dev

### DIFF
--- a/infra/k8s/overlays/prod/kustomization.yaml
+++ b/infra/k8s/overlays/prod/kustomization.yaml
@@ -13,10 +13,10 @@ patches:
 # Image versions for prod environment (updated via promotion PR)
 images:
 - name: seanmckdemo.azurecr.io/bias-scoring-service
-  newTag: main-bab875f
+  newTag: main-4a40be4
 - name: seanmckdemo.azurecr.io/linuxfirst-azuredocs-db-migrations
-  newTag: main-bab875f
+  newTag: main-4a40be4
 - name: seanmckdemo.azurecr.io/queue-worker
-  newTag: main-64a8f5f
+  newTag: main-4a40be4
 - name: seanmckdemo.azurecr.io/webui
-  newTag: main-f1b54ff
+  newTag: main-4a40be4


### PR DESCRIPTION
## Summary
- Promotes all services from dev to prod (main-4a40be4)
- Includes the durable queue fix that prevents KEDA scaler errors when RabbitMQ restarts

## Services promoted
- queue-worker: main-64a8f5f → main-4a40be4
- webui: main-f1b54ff → main-4a40be4
- bias-scoring-service: main-bab875f → main-4a40be4
- linuxfirst-azuredocs-db-migrations: main-bab875f → main-4a40be4

## Post-merge steps for prod
After ArgoCD syncs, you'll need to delete the old non-durable queues so the new durable ones can be created:

```bash
kubectl exec -n azuredocs-app deploy/rabbitmq -- rabbitmqctl delete_queue scan_tasks
kubectl exec -n azuredocs-app deploy/rabbitmq -- rabbitmqctl delete_queue changed_files
kubectl exec -n azuredocs-app deploy/rabbitmq -- rabbitmqctl delete_queue llm_scoring
```

Verify queues are now durable:
```bash
kubectl exec -n azuredocs-app deploy/rabbitmq -- rabbitmqctl list_queues name durable
```