### PR TITLE
feat(web): improve problematic pages UX with readable titles and visu…

### DIFF
--- a/services/web/src/jinja_env.py
+++ b/services/web/src/jinja_env.py
@@ -1,10 +1,76 @@
 import os
+import re
 from fastapi.templating import Jinja2Templates
 from markdown import markdown as md_lib
 
 def markdown_filter(text):
     return md_lib(text or "")
 
+def truncate_url_filter(url, max_length=60):
+    """Truncate URL for display, keeping the end (most specific part)."""
+    if not url or len(url) <= max_length:
+        return url
+    # Keep the last part of the URL (the filename)
+    parts = url.split('/')
+    filename = parts[-1] if parts else url
+    if len(filename) >= max_length - 3:
+        return '...' + filename[-(max_length-3):]
+    remaining = max_length - len(filename) - 4  # 4 for ".../"
+    prefix = '/'.join(parts[:-1])
+    if len(prefix) > remaining:
+        prefix = '...' + prefix[-(remaining-3):]
+    return prefix + '/' + filename
+
+def url_to_title_filter(url):
+    """Extract a human-readable title from a GitHub docs URL.
+
+    Example:
+    https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/active-directory-b2c/access-tokens.md
+    → "Active Directory B2C: Access Tokens"
+    """
+    if not url:
+        return "Untitled Page"
+
+    try:
+        # Extract the path after /articles/ or similar patterns
+        path_match = re.search(r'/articles/([^/]+)/([^/]+?)(?:\.md)?$', url)
+        if path_match:
+            folder = path_match.group(1)
+            filename = path_match.group(2)
+
+            # Convert kebab-case to Title Case
+            def to_title(s):
+                # Handle common acronyms
+                acronyms = {'b2c', 'b2b', 'api', 'sdk', 'cli', 'sql', 'vm', 'vms', 'aks', 'acr', 'dns', 'ssl', 'tls', 'ssh', 'rbac', 'aad', 'arm'}
+                words = s.replace('-', ' ').replace('_', ' ').split()
+                titled = []
+                for word in words:
+                    if word.lower() in acronyms:
+                        titled.append(word.upper())
+                    else:
+                        titled.append(word.capitalize())
+                return ' '.join(titled)
+
+            folder_title = to_title(folder)
+            file_title = to_title(filename)
+
+            # Avoid redundancy if folder and file have similar names
+            if file_title.lower().startswith(folder_title.lower().split()[0].lower()):
+                return file_title
+
+            return f"{folder_title}: {file_title}"
+
+        # Fallback: just get the last path segment
+        parts = url.rstrip('/').split('/')
+        filename = parts[-1] if parts else url
+        filename = re.sub(r'\.md$', '', filename)
+        return filename.replace('-', ' ').replace('_', ' ').title()
+
+    except Exception:
+        return url
+
 TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "templates")
 templates = Jinja2Templates(directory=TEMPLATES_DIR)
 templates.env.filters['markdown'] = markdown_filter
+templates.env.filters['truncate_url'] = truncate_url_filter
+templates.env.filters['url_to_title'] = url_to_title_filter

--- a/services/web/src/main.py
+++ b/services/web/src/main.py
@@ -17,9 +17,7 @@ import time
 import pika
 from packages.scorer.llm_client import LLMClient
 import requests
-import re
 import httpx
-from markdown import markdown as md_lib
 from functools import lru_cache
 from routes import admin, scan, llm, websocket, docset, auth, feedback, docpage
 from routes.scan import enqueue_scan_task
@@ -66,29 +64,7 @@ print(f"[DEBUG] Static directory: {STATIC_DIR}")
 print(f"[DEBUG] Static directory exists: {os.path.exists(STATIC_DIR)}")
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
-# Register markdown filter for Jinja2
-
-def markdown_filter(text):
-    return md_lib(text or "")
-
-templates.env.filters['markdown'] = markdown_filter
-
-def truncate_url_filter(url, max_length=60):
-    """Truncate URL for display, keeping the end (most specific part)."""
-    if not url or len(url) <= max_length:
-        return url
-    # Keep the last part of the URL (the filename)
-    parts = url.split('/')
-    filename = parts[-1] if parts else url
-    if len(filename) >= max_length - 3:
-        return '...' + filename[-(max_length-3):]
-    remaining = max_length - len(filename) - 4  # 4 for ".../"
-    prefix = '/'.join(parts[:-1])
-    if len(prefix) > remaining:
-        prefix = '...' + prefix[-(remaining-3):]
-    return prefix + '/' + filename
-
-templates.env.filters['truncate_url'] = truncate_url_filter
+# Register additional Jinja2 filters (markdown, truncate_url, url_to_title are in jinja_env.py)
 
 def format_doc_set_name_filter(doc_set):
     """Jinja2 filter wrapper for format_doc_set_name."""

--- a/services/web/src/routes/scan.py
+++ b/services/web/src/routes/scan.py
@@ -1,6 +1,5 @@
 from fastapi import APIRouter, Request, HTTPException, Cookie, Depends
 from fastapi.responses import HTMLResponse, JSONResponse
-from fastapi.templating import Jinja2Templates
 from shared.utils.database import SessionLocal
 from shared.models import Scan, Page, Snippet, User
 from datetime import datetime
@@ -12,11 +11,9 @@ import pika
 import json
 from shared.utils.bias_utils import is_page_biased, get_page_priority
 from routes.auth import get_current_user
+from jinja_env import templates
 
 router = APIRouter()
-
-TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "../templates")
-templates = Jinja2Templates(directory=TEMPLATES_DIR)
 
 
 @router.get("/scan/{scan_id}")

--- a/services/web/src/templates/feedback_widget.html
+++ b/services/web/src/templates/feedback_widget.html
@@ -61,12 +61,11 @@
             <!-- Unauthenticated user - show login prompt -->
             <div class="feedback-login-prompt">
                 <p class="feedback-prompt-text">
-                    <span class="feedback-icon">🔐</span>
+                    <span class="feedback-icon">💬</span>
                     Help us improve by rating this assessment
                 </p>
-                <a href="/auth/github/login?redirect={% if scan is defined %}/scan/{{ scan.id }}{% else %}{{ request.url }}{% endif %}" class="btn btn-primary btn-sm">
-                    <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" 
-                         alt="GitHub" style="width: 16px; height: 16px; vertical-align: middle;">
+                <a href="/auth/github/login?redirect={% if scan is defined %}/scan/{{ scan.id }}{% else %}{{ request.url }}{% endif %}" class="btn btn-primary">
+                    <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub">
                     Sign in with GitHub
                 </a>
             </div>
@@ -214,17 +213,51 @@
 }
 
 .feedback-login-prompt {
-    text-align: center;
-    padding: 1em;
-    background: rgba(255, 255, 255, 0.7);
-    border-radius: 6px;
-    border: 1px solid #e5e7eb;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem 1.25rem;
+    background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+    border-radius: 8px;
+    border: 1px solid #e2e8f0;
 }
 
 .feedback-prompt-text {
-    margin: 0 0 0.75em 0;
-    color: #6b7280;
-    font-size: 0.9em;
+    margin: 0;
+    color: #475569;
+    font-size: 0.9rem;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.feedback-login-prompt .btn-primary {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.625rem 1.25rem;
+    background: #24292f;
+    color: #ffffff;
+    font-size: 0.875rem;
+    font-weight: 600;
+    border-radius: 8px;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: all 0.15s ease;
+}
+
+.feedback-login-prompt .btn-primary:hover {
+    background: #32383f;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(36, 41, 47, 0.25);
+}
+
+.feedback-login-prompt .btn-primary img {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
 }
 
 .feedback-status {
@@ -253,20 +286,36 @@
         padding: 0.75em;
         font-size: 0.85em;
     }
-    
+
     .feedback-buttons {
         flex-direction: column;
         gap: 0.4em;
     }
-    
+
     .feedback-btn {
         justify-content: center;
         padding: 0.6em 1em;
     }
-    
+
     .comment-actions {
         flex-direction: column;
         gap: 0.4em;
+    }
+
+    .feedback-login-prompt {
+        flex-direction: column;
+        text-align: center;
+        padding: 1rem;
+        gap: 0.75rem;
+    }
+
+    .feedback-prompt-text {
+        justify-content: center;
+    }
+
+    .feedback-login-prompt .btn-primary {
+        width: 100%;
+        justify-content: center;
     }
 }
 </style>

--- a/services/web/src/templates/scan_details_partial.html
+++ b/services/web/src/templates/scan_details_partial.html
@@ -350,28 +350,45 @@
                 <div class="page-card" data-priority="{{ page['priority_label']|lower }}">
                     <!-- Card Header -->
                     <div class="page-card-header">
-                        <div class="page-card-title">
-                            <a href="{{ page.url }}" target="_blank" rel="noopener noreferrer" class="page-card-url">{{ page.url }}</a>
+                        <div class="page-card-title-group">
+                            <span class="page-card-title">{{ page.url|url_to_title }}</span>
+                            <a href="{{ page.url }}" target="_blank" rel="noopener noreferrer" class="page-card-url">
+                                <svg class="page-card-url-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                                    <polyline points="15,3 21,3 21,9"></polyline>
+                                    <line x1="10" y1="14" x2="21" y2="3"></line>
+                                </svg>
+                                {{ page.url|truncate_url }}
+                            </a>
                         </div>
-                        <div class="page-card-actions">
+                        <div class="page-card-priority">
+                            <span class="priority-indicator priority-indicator-{{ page['priority_label']|lower }}">
+                                {{ page['priority_label'] }} Priority
+                            </span>
                             <a href="/docpage/{{ page.id }}" class="page-detail-link">View Details →</a>
                         </div>
                     </div>
 
-                    <!-- Badges Row -->
-                    <div class="page-card-badges">
-                        {% if page.mcp_holistic and page.mcp_holistic.get('review_method') == 'llm' %}
-                            <span class="badge badge-review-llm">LLM Reviewed</span>
-                        {% elif page.mcp_holistic and page.mcp_holistic.get('review_method') == 'llm_pending' %}
-                            <span class="badge badge-review-pending">LLM Pending</span>
-                        {% elif page.mcp_holistic and page.mcp_holistic.get('review_method') == 'heuristic_skip' %}
-                            <span class="badge badge-review-heuristic">Heuristic Skip</span>
-                        {% elif page.mcp_holistic and page.mcp_holistic.get('review_method') == 'llm_error' %}
-                            <span class="badge badge-review-error">LLM Error</span>
-                        {% else %}
-                            <span class="badge badge-review-unknown">Not Scored</span>
-                        {% endif %}
-                        <span class="badge badge-priority-{{ page['priority_label']|lower }}">{{ page['priority_label'] }} Priority</span>
+                    <!-- Metadata Row -->
+                    <div class="page-card-meta">
+                        <div class="meta-item">
+                            <span class="meta-label">Reviewed by:</span>
+                            {% if page.mcp_holistic and page.mcp_holistic.get('review_method') == 'llm' %}
+                                <span class="meta-value meta-value-llm">LLM Analysis</span>
+                            {% elif page.mcp_holistic and page.mcp_holistic.get('review_method') == 'llm_pending' %}
+                                <span class="meta-value meta-value-pending">Pending LLM Review</span>
+                            {% elif page.mcp_holistic and page.mcp_holistic.get('review_method') == 'heuristic_skip' %}
+                                <span class="meta-value meta-value-heuristic">Heuristic Rules</span>
+                            {% elif page.mcp_holistic and page.mcp_holistic.get('review_method') == 'llm_error' %}
+                                <span class="meta-value meta-value-error">LLM Error</span>
+                            {% else %}
+                                <span class="meta-value">Unknown</span>
+                            {% endif %}
+                        </div>
+                        <div class="meta-item">
+                            <span class="meta-label">Issues:</span>
+                            <span class="meta-value">{{ page.mcp_holistic.get('bias_types', [])|length }} bias type{{ 's' if page.mcp_holistic.get('bias_types', [])|length != 1 else '' }}</span>
+                        </div>
                     </div>
 
                     <!-- Card Body - Analysis Content -->

--- a/services/web/static/dashboard.css
+++ b/services/web/static/dashboard.css
@@ -710,7 +710,7 @@ h1 {
     border-left: 4px solid #10b981;
 }
 
-/* Card header with URL */
+/* Card header with title and priority */
 .page-card-header {
     display: flex;
     align-items: flex-start;
@@ -721,32 +721,77 @@ h1 {
     border-bottom: 1px solid #e5e7eb;
 }
 
-.page-card-title {
+.page-card-title-group {
     flex: 1;
     min-width: 0;
 }
 
-.page-card-url {
+.page-card-title {
     display: block;
-    font-size: 0.9375rem;
-    font-weight: 600;
-    color: #1e40af;
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: #1e293b;
+    line-height: 1.35;
+    margin-bottom: 0.375rem;
+}
+
+.page-card-url {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: #64748b;
     text-decoration: none;
-    word-break: break-word;
+    word-break: break-all;
     line-height: 1.4;
     transition: color 0.15s ease;
 }
 
 .page-card-url:hover {
-    color: #1e3a8a;
-    text-decoration: underline;
+    color: #1e40af;
 }
 
-.page-card-actions {
+.page-card-url-icon {
+    flex-shrink: 0;
+    opacity: 0.6;
+}
+
+/* Priority indicator - prominent corner badge */
+.page-card-priority {
     display: flex;
-    align-items: center;
+    flex-direction: column;
+    align-items: flex-end;
     gap: 0.5rem;
     flex-shrink: 0;
+}
+
+.priority-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    border-radius: 8px;
+    color: #ffffff;
+}
+
+.priority-indicator-high {
+    background: linear-gradient(135deg, #dc2626 0%, #b91c1c 100%);
+    box-shadow: 0 2px 8px rgba(220, 38, 38, 0.3);
+}
+
+.priority-indicator-medium {
+    background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+    box-shadow: 0 2px 8px rgba(245, 158, 11, 0.3);
+}
+
+.priority-indicator-low {
+    background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+    box-shadow: 0 2px 8px rgba(16, 185, 129, 0.3);
 }
 
 .page-detail-link {
@@ -770,15 +815,49 @@ h1 {
     background: #eff6ff;
 }
 
-/* Badges row */
-.page-card-badges {
+/* Review source - subtle metadata bar */
+.page-card-meta {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.875rem 1.5rem;
+    gap: 1rem;
+    padding: 0.625rem 1.5rem;
     background: #ffffff;
     border-bottom: 1px solid #f1f5f9;
+    font-size: 0.75rem;
+    color: #64748b;
+}
+
+.meta-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+}
+
+.meta-label {
+    font-weight: 500;
+    color: #94a3b8;
+}
+
+.meta-value {
+    font-weight: 600;
+    color: #475569;
+}
+
+.meta-value-llm {
+    color: #1e40af;
+}
+
+.meta-value-pending {
+    color: #7c3aed;
+}
+
+.meta-value-heuristic {
+    color: #64748b;
+}
+
+.meta-value-error {
+    color: #dc2626;
 }
 
 /* Unified badge styling */
@@ -982,15 +1061,33 @@ h1 {
     .page-card-header {
         flex-direction: column;
         padding: 1rem;
+        gap: 0.75rem;
     }
 
-    .page-card-actions {
+    .page-card-title-group {
+        order: 2;
+    }
+
+    .page-card-priority {
+        order: 1;
+        flex-direction: row;
+        align-items: center;
         width: 100%;
-        justify-content: flex-start;
+        justify-content: space-between;
     }
 
-    .page-card-badges {
-        padding: 0.75rem 1rem;
+    .priority-indicator {
+        padding: 0.375rem 0.75rem;
+        font-size: 0.75rem;
+    }
+
+    .page-card-title {
+        font-size: 1rem;
+    }
+
+    .page-card-meta {
+        padding: 0.5rem 1rem;
+        gap: 0.75rem;
     }
 
     .page-card-body {
@@ -1015,7 +1112,20 @@ h1 {
 
 @media (max-width: 480px) {
     .page-card-url {
-        font-size: 0.875rem;
+        font-size: 0.75rem;
+    }
+
+    .page-card-title {
+        font-size: 0.9375rem;
+    }
+
+    .priority-indicator {
+        padding: 0.3125rem 0.625rem;
+        font-size: 0.6875rem;
+    }
+
+    .meta-item {
+        font-size: 0.6875rem;
     }
 
     .badge {


### PR DESCRIPTION
…al hierarchy

- Add url_to_title Jinja2 filter to convert GitHub URLs to human-readable titles (e.g., "Active Directory B2C: Access Tokens")
- Separate priority and review source with distinct visual treatments:
  - Priority: prominent gradient badge in card header corner
  - Review source: subtle metadata bar with label/value pairs
- Redesign feedback widget GitHub sign-in button with proper sizing, horizontal layout, and consistent styling
- Add external link icon for page URLs
- Improve mobile responsive layout for new card structure
- Consolidate Jinja2 filters in jinja_env.py for shared template access
- Fix scan.py to use shared templates instance with all filters