### PR TITLE
Fix ArgoCD sync failure by re-enabling db-migrate hook annotations

### DIFF
--- a/infra/k8s/base/db-migrate.yaml
+++ b/infra/k8s/base/db-migrate.yaml
@@ -3,9 +3,9 @@ kind: Job
 metadata:
   name: db-migrate
   namespace: azuredocs-app
-  # Hook annotations removed - run migrations manually before promotions
-  # argocd.argoproj.io/hook: PreSync
-  # argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
   template:
     metadata:


### PR DESCRIPTION
The db-migrate Job was failing to sync because Jobs are immutable in Kubernetes. Without the hook annotations, ArgoCD tried to patch the existing Job instead of replacing it.

Re-enable PreSync hook with BeforeHookCreation delete policy so ArgoCD deletes the old Job before creating a new one on each sync.