### PR TITLE
fix(queue): add persistent delivery mode to RabbitMQ messages

### DIFF
--- a/scripts/enqueue_github_scan.py
+++ b/scripts/enqueue_github_scan.py
@@ -44,7 +44,12 @@ def enqueue_scan_task(url, scan_id, source, force_rescan=False):
     print(f"[DEBUG] Enqueueing message: {message}")
     
     print(f"[INFO] Enqueuing scan task: url={url}, scan_id={scan_id}, source={source}, force_rescan={force_rescan}")
-    channel.basic_publish(exchange='', routing_key='scan_tasks', body=message)
+    channel.basic_publish(
+        exchange='',
+        routing_key='scan_tasks',
+        body=message,
+        properties=pika.BasicProperties(delivery_mode=2)  # Persistent
+    )
     
     queue_state = channel.queue_declare(queue='scan_tasks', passive=True)
     print(f"[INFO] scan_tasks queue message count after publish: {queue_state.method.message_count}")

--- a/services/web/src/routes/scan.py
+++ b/services/web/src/routes/scan.py
@@ -204,7 +204,12 @@ def enqueue_scan_task(url, scan_id, source, force_rescan=False):
     }
     message = json.dumps(task_data)
     print(f"[DEBUG] Enqueuing scan task: url={url}, scan_id={scan_id}, source={source}, force_rescan={force_rescan}")
-    channel.basic_publish(exchange='', routing_key='scan_tasks', body=message)
+    channel.basic_publish(
+        exchange='',
+        routing_key='scan_tasks',
+        body=message,
+        properties=pika.BasicProperties(delivery_mode=2)  # Persistent
+    )
     queue_state = channel.queue_declare(queue='scan_tasks', passive=True)
     print(f"[DEBUG] scan_tasks queue message count after publish: {queue_state.method.message_count}")
     connection.close()

--- a/shared/infrastructure/queue_service.py
+++ b/shared/infrastructure/queue_service.py
@@ -139,7 +139,8 @@ class QueueService:
                 self.channel.basic_publish(
                     exchange='',
                     routing_key=self.queue_name,
-                    body=message
+                    body=message,
+                    properties=pika.BasicProperties(delivery_mode=2)  # Persistent
                 )
                 # Log task info without the full message content to avoid polluting logs
                 task_info = {k: v for k, v in task_data.items() if k != 'page_content'}
@@ -189,7 +190,8 @@ class QueueService:
                     self.channel.basic_publish(
                         exchange='',
                         routing_key=queue_name,
-                        body=message_body
+                        body=message_body,
+                        properties=pika.BasicProperties(delivery_mode=2)  # Persistent
                     )
 
                 self.logger.info(f"Published {len(messages)} messages to {queue_name} queue")
@@ -236,7 +238,8 @@ class QueueService:
                 self.channel.basic_publish(
                     exchange='',
                     routing_key=queue_name,
-                    body=message_body
+                    body=message_body,
+                    properties=pika.BasicProperties(delivery_mode=2)  # Persistent
                 )
 
                 return True


### PR DESCRIPTION
## Summary

- Add `delivery_mode=2` to all RabbitMQ `basic_publish` calls to ensure messages survive broker restarts
- Completes the fix for #89 which added persistent storage to RabbitMQ but didn't mark messages as persistent

## Test plan

- [x] Deploy to dev
- [ ] Trigger a scan to populate queues with messages
- [ ] Restart RabbitMQ pod (`kubectl delete pod rabbitmq-0`)
- [ ] Verify messages survive the restart