### PR TITLE
fix: add StatefulSet and PVC to ArgoCD project whitelist

### DIFF
--- a/infra/argocd/projects/linuxfirst-docs.yaml
+++ b/infra/argocd/projects/linuxfirst-docs.yaml
@@ -35,9 +35,13 @@ spec:
       kind: Service
     - group: ''
       kind: ServiceAccount
+    - group: ''
+      kind: PersistentVolumeClaim
     # Workloads
     - group: apps
       kind: Deployment
+    - group: apps
+      kind: StatefulSet
     - group: batch
       kind: Job
     - group: batch


### PR DESCRIPTION
## Summary

- Add `StatefulSet` and `PersistentVolumeClaim` to the `namespaceResourceWhitelist` in the `linuxfirst-docs` ArgoCD project
- Enables ArgoCD to sync the RabbitMQ StatefulSet that provides persistent storage for message queue durability

Fixes #108

## Test plan

- [ ] Verify YAML syntax with `kubectl apply --dry-run=client`
- [ ] After merge, confirm ArgoCD sync succeeds and shows `Synced`/`Healthy` status
- [ ] Run post-fix SQL to enable incremental scanning for existing scans