### PR TITLE
fix(prod): increase RabbitMQ memory and probe timeouts

### DIFF
--- a/infra/k8s/overlays/prod/kustomization.yaml
+++ b/infra/k8s/overlays/prod/kustomization.yaml
@@ -9,6 +9,7 @@ patches:
 - path: service-account-patch.yaml
 - path: secret-provider-class-patch.yaml
 - path: sc-azuredocsdbconnection-secret-patch.yaml
+- path: rabbitmq-patch.yaml
 
 # Image versions for prod environment (updated via promotion PR)
 images:

--- a/infra/k8s/overlays/prod/rabbitmq-patch.yaml
+++ b/infra/k8s/overlays/prod/rabbitmq-patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: rabbitmq
+  namespace: azuredocs-app
+spec:
+  template:
+    spec:
+      containers:
+        - name: rabbitmq
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "200m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"
+          livenessProbe:
+            initialDelaySeconds: 60
+            timeoutSeconds: 30
+          readinessProbe:
+            initialDelaySeconds: 45
+            timeoutSeconds: 15


### PR DESCRIPTION
## Summary

- Increases RabbitMQ memory limits from 512Mi to 2Gi to prevent crash loops during startup
- Increases probe timeouts and initial delays to accommodate startup under memory pressure
- Creates prod-specific Kustomize patch to keep base config unchanged for dev

## Changes

| Setting | Before | After |
|---------|--------|-------|
| Memory request | 256Mi | 1Gi |
| Memory limit | 512Mi | 2Gi |
| CPU request | 100m | 200m |
| CPU limit | 500m | 1000m |
| Liveness initial delay | 30s | 60s |
| Liveness timeout | 10s | 30s |
| Readiness initial delay | 25s | 45s |
| Readiness timeout | 5s | 15s |

Fixes #120

## Test plan

- [ ] Verify `kustomize build infra/k8s/overlays/prod` succeeds
- [ ] Deploy to prod and verify RabbitMQ pod starts without crash loop
- [ ] Confirm workers can connect to RabbitMQ