### PR TITLE
fix: use cast() instead of .astext for JSON column query

### DIFF
--- a/shared/application/scan_completion_service.py
+++ b/shared/application/scan_completion_service.py
@@ -1,5 +1,6 @@
 """Service for checking and finalizing scan completion"""
 import datetime
+from sqlalchemy import cast, String
 from sqlalchemy.orm import Session
 from shared.models import Page, Scan, Snippet
 from shared.utils.logging import get_logger
@@ -43,7 +44,7 @@ class ScanCompletionService:
             # Check if any pages are still pending LLM scoring
             pending_llm = self.db.query(Page).filter(
                 Page.scan_id == scan_id,
-                Page.mcp_holistic['review_method'].astext == 'llm_pending'
+                cast(Page.mcp_holistic['review_method'], String) == 'llm_pending'
             ).count()
 
             if pending_llm > 0:


### PR DESCRIPTION
## Summary

- Replace PostgreSQL-specific `.astext` accessor with SQLAlchemy's `cast()` for querying the `mcp_holistic` JSON column
- The `.astext` accessor only works with `JSONB` type, but `mcp_holistic` is defined as generic `JSON`

This was causing scan completion checks to fail with:
```
Neither 'BinaryExpression' object nor 'Comparator' object has an attribute 'astext'
```

## Test plan

- [ ] Deploy to dev environment
- [ ] Run a scan and verify it transitions to `completed` status
- [ ] Check llm-worker logs for absence of the `.astext` error

Fixes #122