### PR TITLE
fix(config): use public Azure docs repos directly

### DIFF
--- a/config/repos.yaml
+++ b/config/repos.yaml
@@ -4,19 +4,21 @@
 
 repos:
   - owner: MicrosoftDocs
-    name: azure-docs-pr
-    public_name: azure-docs  # Public repo equivalent for fallback
+    name: azure-docs
     branch: main
     articles_path: articles
 
   - owner: MicrosoftDocs
-    name: azure-management-docs-pr
-    public_name: azure-management-docs
+    name: azure-management-docs
     branch: main
     articles_path: articles
 
   - owner: MicrosoftDocs
-    name: azure-compute-docs-pr
-    public_name: azure-compute-docs
+    name: azure-compute-docs
+    branch: main
+    articles_path: articles
+
+  - owner: MicrosoftDocs
+    name: azure-aks-docs
     branch: main
     articles_path: articles


### PR DESCRIPTION
## Summary

- Switch from private `-pr` repos to public repos to fix incremental scanning
- The private repos return 404, causing fallback and baseline lookup failures that resulted in full rescans instead of incremental scans
- Adds `azure-aks-docs` to the tracked repositories

Fixes #131