### PR TITLE
fix(k8s): limit bias-scoring-service replicas and RPM to prevent rate limiting

### DIFF
--- a/infra/k8s/base/bias-scoring-service-keda.yaml
+++ b/infra/k8s/base/bias-scoring-service-keda.yaml
@@ -34,9 +34,11 @@ spec:
       containers:
         - name: bias-scoring-service
           image: seanmckdemo.azurecr.io/bias-scoring-service
-          env:            
+          env:
             - name: AZURE_OPENAI_DEPLOYMENT
               value: "gpt-4.1"
+            - name: AZURE_OPENAI_RPM
+              value: "10"
           envFrom:
             - secretRef:
                 name: sc-linuxdocsazureopenai-secret
@@ -73,7 +75,7 @@ spec:
   scaleTargetRef:
     name: bias-scoring-service
   minReplicaCount: 2
-  maxReplicaCount: 10
+  maxReplicaCount: 2
   cooldownPeriod: 60
   triggers:
   - type: cpu


### PR DESCRIPTION
## Summary

- Add `AZURE_OPENAI_RPM=10` environment variable to limit requests per replica
- Reduce `maxReplicaCount` from 10 to 2 in KEDA ScaledObject

This keeps the bias-scoring-service within the 20 RPM Azure OpenAI quota by splitting it across 2 replicas at 10 RPM each, preventing 429 rate limit errors that were causing 503 failures after retry exhaustion.

Fixes #135