### PR TITLE
fix(progress): use file-based counters for scan progress calculation

### DIFF
--- a/services/web/src/routes/scan.py
+++ b/services/web/src/routes/scan.py
@@ -30,10 +30,10 @@ async def scan_details(scan_id: int, request: Request, current_user: Optional[Us
     flagged_count = len(flagged_pages)
     percent_flagged = (flagged_count / scanned_count * 100) if scanned_count else 0
     
-    # Calculate initial progress for the UI
+    # Calculate initial progress for the UI (using file-based counters for GitHub scans)
     initial_progress = 0
-    if scan.total_pages_found and scan.total_pages_found > 0:
-        initial_progress = (scan.pages_processed / scan.total_pages_found) * 100
+    if scan.total_files_queued and scan.total_files_queued > 0:
+        initial_progress = (scan.total_files_completed / scan.total_files_queued) * 100
     elif scan.status == 'completed':
         initial_progress = 100
     
@@ -115,10 +115,10 @@ async def scan_details_json(scan_id: int, request: Request, current_user: Option
     flagged_count = len(flagged_pages)
     percent_flagged = (flagged_count / scanned_count * 100) if scanned_count else 0
     
-    # Calculate initial progress for the UI
+    # Calculate initial progress for the UI (using file-based counters for GitHub scans)
     initial_progress = 0
-    if scan.total_pages_found and scan.total_pages_found > 0:
-        initial_progress = (scan.pages_processed / scan.total_pages_found) * 100
+    if scan.total_files_queued and scan.total_files_queued > 0:
+        initial_progress = (scan.total_files_completed / scan.total_files_queued) * 100
     elif scan.status == 'completed':
         initial_progress = 100
     

--- a/services/web/src/routes/websocket.py
+++ b/services/web/src/routes/websocket.py
@@ -81,10 +81,10 @@ async def get_scan_progress(scan_id: int):
         if not scan:
             raise HTTPException(status_code=404, detail="Scan not found")
         
-        # Calculate page-based overall progress
+        # Calculate file-based overall progress (for GitHub scans)
         overall_progress = 0
-        if scan.total_pages_found and scan.total_pages_found > 0:
-            overall_progress = (scan.pages_processed / scan.total_pages_found) * 100
+        if scan.total_files_queued and scan.total_files_queued > 0:
+            overall_progress = (scan.total_files_completed / scan.total_files_queued) * 100
         elif scan.status == 'completed':
             overall_progress = 100
         

--- a/services/web/src/templates/scan_details_partial.html
+++ b/services/web/src/templates/scan_details_partial.html
@@ -32,7 +32,7 @@
     <!-- Overall Progress Bar -->
     <div class="progress-container">
         <div class="progress-bar-container">
-            {% set initial_progress = (scan.pages_processed / scan.total_pages_found * 100) if scan.total_pages_found and scan.total_pages_found > 0 else (100 if scan.status == 'completed' else 0) %}
+            {% set initial_progress = (scan.total_files_completed / scan.total_files_queued * 100) if scan.total_files_queued and scan.total_files_queued > 0 else (100 if scan.status == 'completed' else 0) %}
             <div class="progress-bar" id="overall-progress-bar" style="width: {{ initial_progress }}%" data-initial-progress="{{ initial_progress }}">{{ initial_progress|round|int }}%</div>
         </div>
     </div>
@@ -87,12 +87,12 @@
         <p><strong>Current Phase:</strong> {{ scan.current_phase }}</p>
         {% endif %}
         
-        {% if scan.total_pages_found %}
-        <p><strong>Pages Found:</strong> {{ scan.total_pages_found }}</p>
+        {% if scan.total_files_queued %}
+        <p><strong>Files Queued:</strong> {{ scan.total_files_queued }}</p>
         {% endif %}
-        
-        {% if scan.pages_processed %}
-        <p><strong>Pages Processed:</strong> {{ scan.pages_processed }}</p>
+
+        {% if scan.total_files_completed %}
+        <p><strong>Files Completed:</strong> {{ scan.total_files_completed }}</p>
         {% endif %}
         
         {% if scan.estimated_completion and scan.status != 'completed' %}

--- a/shared/application/progress_service.py
+++ b/shared/application/progress_service.py
@@ -105,10 +105,10 @@ class ProgressService:
         if scan.phase_progress and phase in scan.phase_progress:
             progress_percentage = scan.phase_progress[phase].get('progress_percentage', 0)
         
-        # Calculate page-based overall progress
+        # Calculate file-based overall progress (for GitHub scans)
         overall_progress = 0
-        if scan.total_pages_found and scan.total_pages_found > 0:
-            overall_progress = (scan.pages_processed / scan.total_pages_found) * 100
+        if scan.total_files_queued and scan.total_files_queued > 0:
+            overall_progress = (scan.total_files_completed / scan.total_files_queued) * 100
         elif scan.status == 'completed':
             overall_progress = 100
         
@@ -207,10 +207,10 @@ class ProgressService:
             try:
                 scan = db.query(Scan).filter(Scan.id == scan_id).first()
                 if scan:
-                    # Calculate page-based overall progress
+                    # Calculate file-based overall progress (for GitHub scans)
                     overall_progress = 0
-                    if scan.total_pages_found and scan.total_pages_found > 0:
-                        overall_progress = (scan.pages_processed / scan.total_pages_found) * 100
+                    if scan.total_files_queued and scan.total_files_queued > 0:
+                        overall_progress = (scan.total_files_completed / scan.total_files_queued) * 100
                     elif scan.status == 'completed':
                         overall_progress = 100
                     


### PR DESCRIPTION
## Summary

- Fixed scan progress stuck at 0% by switching from page-based counters to file-based counters
- Updated progress calculations in routes, WebSocket endpoints, progress service, and templates
- Changed info display labels from "Pages Found/Processed" to "Files Queued/Completed"

Fixes #134

## Test plan

- [ ] Start a new scan from the web UI
- [ ] Verify progress bar increments from 0% toward 100% as files are processed
- [ ] Verify completed scans show 100% progress
- [ ] Verify "Files Queued" and "Files Completed" labels display correctly