### PR TITLE
UX polish: dark theme consistency and improved display

### DIFF
--- a/services/web/src/templates/feedback_widget.html
+++ b/services/web/src/templates/feedback_widget.html
@@ -74,12 +74,13 @@
 </div>
 
 <style>
+/* Feedback widget - uses dark theme variables from dashboard.css */
 .feedback-widget {
     margin-top: 1.5em;
     padding: 1em;
-    background: #f8fafc;
+    background: var(--bg-card);
     border-radius: 8px;
-    border: 1px solid #e2e8f0;
+    border: 1px solid var(--border-color);
     font-size: 0.9em;
 }
 
@@ -92,13 +93,13 @@
 
 .feedback-label {
     font-weight: 600;
-    color: #374151;
+    color: var(--text-primary);
     font-size: 0.95em;
 }
 
 .feedback-stats {
     font-size: 0.8em;
-    color: #6b7280;
+    color: var(--text-secondary);
 }
 
 .feedback-buttons {
@@ -111,34 +112,37 @@
     display: flex;
     align-items: center;
     gap: 0.5em;
-    padding: 0.75em 1.25em; /* Increased padding for larger buttons */
-    border: 1px solid #d1d5db;
+    padding: 0.75em 1.25em;
+    border: 1px solid var(--border-color);
     border-radius: 6px;
-    background: white;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
     cursor: pointer;
     transition: all 0.2s ease;
-    font-size: 1em; /* Slightly larger font size */
+    font-size: 1em;
 }
 
 .feedback-btn:hover {
-    background: #f9fafb;
-    border-color: #9ca3af;
+    background: var(--bg-card-hover);
+    border-color: var(--text-muted);
 }
 
 .feedback-btn.active {
-    background: #2563eb;
-    border-color: #2563eb;
-    color: white;
+    background: var(--accent-yellow);
+    border-color: var(--accent-yellow);
+    color: #0f172a;
 }
 
 .feedback-btn.active.thumbs-up {
-    background: #10b981;
-    border-color: #10b981;
+    background: var(--accent-green);
+    border-color: var(--accent-green);
+    color: #0f172a;
 }
 
 .feedback-btn.active.thumbs-down {
-    background: #ef4444;
-    border-color: #ef4444;
+    background: var(--accent-red);
+    border-color: var(--accent-red);
+    color: white;
 }
 
 .feedback-btn:disabled {
@@ -147,30 +151,36 @@
 }
 
 .feedback-icon {
-    font-size: 1.3em; /* Increased icon size */
+    font-size: 1.3em;
 }
 
 .feedback-comment-section {
     margin-top: 0.75em;
     padding-top: 0.75em;
-    border-top: 1px solid #e5e7eb;
+    border-top: 1px solid var(--border-color);
 }
 
 .feedback-comment {
     width: 100%;
     padding: 0.75em;
-    border: 1px solid #d1d5db;
+    border: 1px solid var(--border-color);
     border-radius: 6px;
-    font-size: 1.1em; /* Increased font size */
-    font-family: 'Arial', sans-serif; /* Nicer font */
+    font-size: 1.1em;
+    font-family: var(--font-body);
     resize: vertical;
     min-height: 80px;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+}
+
+.feedback-comment::placeholder {
+    color: var(--text-muted);
 }
 
 .feedback-comment:focus {
     outline: none;
-    border-color: #2563eb;
-    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    border-color: var(--accent-yellow);
+    box-shadow: 0 0 0 3px var(--accent-yellow-dim);
 }
 
 .comment-actions {
@@ -179,7 +189,7 @@
     margin-top: 0.5em;
 }
 
-.btn {
+.feedback-widget .btn {
     padding: 0.5em 1em;
     border: none;
     border-radius: 6px;
@@ -189,22 +199,23 @@
     transition: all 0.2s ease;
 }
 
-.btn-primary {
-    background: #2563eb;
-    color: white;
+.feedback-widget .btn-primary {
+    background: var(--accent-yellow);
+    color: #0f172a;
 }
 
-.btn-primary:hover {
-    background: #1d4ed8;
+.feedback-widget .btn-primary:hover {
+    background: #eab308;
+    transform: translateY(-1px);
 }
 
-.btn-secondary {
-    background: #6b7280;
-    color: white;
+.feedback-widget .btn-secondary {
+    background: var(--bg-card-hover);
+    color: var(--text-primary);
 }
 
-.btn-secondary:hover {
-    background: #4b5563;
+.feedback-widget .btn-secondary:hover {
+    background: var(--text-muted);
 }
 
 .btn-sm {
@@ -218,14 +229,14 @@
     justify-content: space-between;
     gap: 1rem;
     padding: 1rem 1.25rem;
-    background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+    background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-primary) 100%);
     border-radius: 8px;
-    border: 1px solid #e2e8f0;
+    border: 1px solid var(--border-color);
 }
 
 .feedback-prompt-text {
     margin: 0;
-    color: #475569;
+    color: var(--text-secondary);
     font-size: 0.9rem;
     font-weight: 500;
     display: flex;
@@ -238,8 +249,8 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.625rem 1.25rem;
-    background: #24292f;
-    color: #ffffff;
+    background: var(--accent-yellow);
+    color: #0f172a;
     font-size: 0.875rem;
     font-weight: 600;
     border-radius: 8px;
@@ -249,15 +260,16 @@
 }
 
 .feedback-login-prompt .btn-primary:hover {
-    background: #32383f;
+    background: #eab308;
     transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(36, 41, 47, 0.25);
+    box-shadow: 0 4px 12px rgba(250, 204, 21, 0.25);
 }
 
 .feedback-login-prompt .btn-primary img {
     width: 18px;
     height: 18px;
     border-radius: 50%;
+    filter: brightness(0);
 }
 
 .feedback-status {
@@ -269,15 +281,15 @@
 }
 
 .feedback-status.success {
-    background: #dcfce7;
-    color: #166534;
-    border: 1px solid #bbf7d0;
+    background: var(--accent-green-dim);
+    color: var(--accent-green);
+    border: 1px solid rgba(34, 197, 94, 0.3);
 }
 
 .feedback-status.error {
-    background: #fee2e2;
-    color: #dc2626;
-    border: 1px solid #fecaca;
+    background: var(--accent-red-dim);
+    color: var(--accent-red);
+    border: 1px solid rgba(239, 68, 68, 0.3);
 }
 
 /* Mobile responsive */


### PR DESCRIPTION
## Summary

- Update feedback widget to match dark theme design system (replace hardcoded light colors with CSS variables)
- Show friendly repo names (e.g., "MicrosoftDocs/azure-docs") instead of raw GitHub URLs
- Refactor flagged pages list to use consistent page-card design

## Test plan

- [ ] Verify feedback widget displays correctly on dark theme (buttons, form fields, status messages)
- [ ] Check repo names display as "owner/repo" format in scan details
- [ ] Confirm flagged pages use card layout matching other page lists