### PR TITLE
UX polish: improved styling and design consistency

### DIFF
--- a/services/web/src/templates/feedback_widget.html
+++ b/services/web/src/templates/feedback_widget.html
@@ -64,8 +64,10 @@
                     <span class="feedback-icon">💬</span>
                     Help us improve by rating this assessment
                 </p>
-                <a href="/auth/github/login?redirect={% if scan is defined %}/scan/{{ scan.id }}{% else %}{{ request.url }}{% endif %}" class="btn btn-primary">
-                    <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub">
+                <a href="/auth/github/login?redirect={% if scan is defined %}/scan/{{ scan.id }}{% else %}{{ request.url }}{% endif %}" class="btn-github">
+                    <svg class="github-logo" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+                    </svg>
                     Sign in with GitHub
                 </a>
             </div>
@@ -229,7 +231,7 @@
     justify-content: space-between;
     gap: 1rem;
     padding: 1rem 1.25rem;
-    background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-primary) 100%);
+    background: var(--bg-primary);
     border-radius: 8px;
     border: 1px solid var(--border-color);
 }
@@ -244,32 +246,32 @@
     gap: 0.5rem;
 }
 
-.feedback-login-prompt .btn-primary {
+/* GitHub-branded sign in button */
+.btn-github {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.625rem 1.25rem;
-    background: var(--accent-yellow);
-    color: #0f172a;
+    padding: 0.625rem 1rem;
+    background: #24292f;
+    color: #ffffff;
     font-size: 0.875rem;
-    font-weight: 600;
-    border-radius: 8px;
+    font-weight: 500;
+    border-radius: 6px;
     text-decoration: none;
     white-space: nowrap;
-    transition: all 0.15s ease;
+    border: 1px solid rgba(240, 246, 252, 0.1);
+    transition: background 0.15s ease, border-color 0.15s ease;
 }
 
-.feedback-login-prompt .btn-primary:hover {
-    background: #eab308;
-    transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(250, 204, 21, 0.25);
+.btn-github:hover {
+    background: #32383f;
+    border-color: rgba(240, 246, 252, 0.2);
 }
 
-.feedback-login-prompt .btn-primary img {
+.btn-github .github-logo {
     width: 18px;
     height: 18px;
-    border-radius: 50%;
-    filter: brightness(0);
+    flex-shrink: 0;
 }
 
 .feedback-status {
@@ -325,7 +327,7 @@
         justify-content: center;
     }
 
-    .feedback-login-prompt .btn-primary {
+    .feedback-login-prompt .btn-github {
         width: 100%;
         justify-content: center;
     }


### PR DESCRIPTION
## Summary
- Replaced GitHub logo external image with inline SVG and GitHub-branded dark button colors
- Updated feedback widget to match dark theme design
- Show friendly repo names instead of raw URLs
- Updated flagged pages to use page-card design

## Test plan
- [ ] Verify feedback widget displays correctly in dark theme
- [ ] Confirm GitHub sign-in button renders with proper SVG logo
- [ ] Check repo names display in friendly format
- [ ] Validate page-card design on flagged pages view