### PR TITLE
UX polish: improve scan details page design and fix visual bugs

### DIFF
--- a/services/web/src/templates/scan_details_partial.html
+++ b/services/web/src/templates/scan_details_partial.html
@@ -356,10 +356,10 @@
     </div>
 
     {% if pages and pages|length > 0 %}
-        {% set has_flagged = false %}
+        {% set ns = namespace(has_flagged=false) %}
         {% for page in pages %}
             {% if page.mcp_holistic and page.mcp_holistic.get('bias_types') %}
-                {% set has_flagged = true %}
+                {% set ns.has_flagged = true %}
                 <div class="page-card" data-priority="{{ page['priority_label']|lower }}">
                     <!-- Card Header -->
                     <div class="page-card-header">
@@ -457,7 +457,7 @@
             {% endif %}
         {% endfor %}
 
-        {% if not has_flagged %}
+        {% if not ns.has_flagged %}
         <div class="no-issues-found">
             <div class="no-issues-found-icon">🐧</div>
             <p class="no-issues-found-text">No problematic pages found in this scan. All pages appear to be Linux-friendly!</p>


### PR DESCRIPTION
## Summary

- Refactor flagged pages to use consistent page-card design
- Show friendly repo names instead of raw GitHub URLs
- Update feedback widget styling to match dark theme
- Replace external GitHub logo with inline SVG using branded colors
- Fix bug where "No problematic pages" message appeared even when flagged pages were displayed

## Test plan

- [ ] Verify flagged pages display with new card design
- [ ] Check repo names show friendly format (e.g., "azure-docs" instead of full URL)
- [ ] Confirm feedback widget matches dark theme styling
- [ ] Verify GitHub logo displays correctly with branded colors
- [ ] Confirm "No problematic pages" message only appears when there are no flagged pages