### PR TITLE
fix: use shared Jinja2 templates instance with custom filters

### DIFF
--- a/services/web/src/routes/admin.py
+++ b/services/web/src/routes/admin.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Request, Form, HTTPException, Cookie
 from fastapi.responses import RedirectResponse, JSONResponse
-from fastapi.templating import Jinja2Templates
+from jinja_env import templates
 from shared.utils.database import SessionLocal
 from shared.models import Scan, Page, Snippet
 from sqlalchemy import text
@@ -185,10 +185,6 @@ def cleanup_expired_sessions():
         logging.info(f"Cleanup complete")
     else:
         logging.info("Redis handles session expiration automatically")
-
-# Templates
-TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "../templates")
-templates = Jinja2Templates(directory=TEMPLATES_DIR)
 
 @router.get("/admin/login")
 async def admin_login_page(request: Request):

--- a/services/web/src/routes/docpage.py
+++ b/services/web/src/routes/docpage.py
@@ -1,22 +1,18 @@
 from fastapi import APIRouter, Request, HTTPException, Depends, Query
 from fastapi.responses import HTMLResponse
-from fastapi.templating import Jinja2Templates
+from jinja_env import templates
 from shared.utils.database import SessionLocal
 from shared.models import Scan, Page, Snippet, User
 from shared.utils.bias_utils import is_page_biased
 from shared.config import AZURE_DOCS_REPOS, get_repo_from_url
 from routes.auth import get_current_user
 from typing import Optional
-import os
 import json
 import re
 from urllib.parse import urlparse
 from datetime import datetime
 
 router = APIRouter()
-
-TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "../templates")
-templates = Jinja2Templates(directory=TEMPLATES_DIR)
 
 
 def get_github_url(page_url: str) -> str:


### PR DESCRIPTION
## Summary
- Import `templates` from `jinja_env` instead of creating local `Jinja2Templates` instances in `admin.py` and `docpage.py`
- Ensures custom filters like `url_to_repo_display` are available, fixing the 500 Internal Server Error on `/admin`

## Test plan
- [ ] Run `./scripts/start-dev.sh` to start the development environment
- [ ] Navigate to `/admin` and verify the page loads without a 500 error
- [ ] Navigate to a doc page detail view and verify it renders correctly

Fixes #152