### PR TITLE
fix: use equality comparison for rating filter instead of IS TRUE

### DIFF
--- a/services/web/src/routes/admin.py
+++ b/services/web/src/routes/admin.py
@@ -510,9 +510,9 @@ def get_admin_feedback(
 
     if rating:
         if rating == "up":
-            base_query = base_query.filter(UserFeedback.rating.is_(True))
+            base_query = base_query.filter(UserFeedback.rating == True)
         elif rating == "down":
-            base_query = base_query.filter(UserFeedback.rating.is_(False))
+            base_query = base_query.filter(UserFeedback.rating == False)
 
     if has_comment:
         if has_comment == "yes":
@@ -560,8 +560,8 @@ def get_admin_feedback(
     # not all feedback items in the database
     stats_query = base_query.with_entities(
         func.count(UserFeedback.id).label('total'),
-        func.sum(case((UserFeedback.rating.is_(True), 1), else_=0)).label('thumbs_up'),
-        func.sum(case((UserFeedback.rating.is_(False), 1), else_=0)).label('thumbs_down'),
+        func.sum(case((UserFeedback.rating == True, 1), else_=0)).label('thumbs_up'),
+        func.sum(case((UserFeedback.rating == False, 1), else_=0)).label('thumbs_down'),
         func.sum(case((func.coalesce(func.length(func.trim(UserFeedback.comment)), 0) > 0, 1), else_=0)).label('has_comments')
     ).first()
 


### PR DESCRIPTION
The rating column is stored as varchar in the database, not boolean. PostgreSQL's IS TRUE/IS FALSE syntax only works with boolean columns.