### PR TITLE
Cache PyGithub Repository object to reduce API calls

### DIFF
--- a/shared/infrastructure/github_service.py
+++ b/shared/infrastructure/github_service.py
@@ -58,7 +58,7 @@ class GitHubService:
             # Don't let rate limit checking break the actual operation
             self.logger.warning(f"Could not check rate limit: {e}")
 
-    def _get_cached_repo(self, repo_full_name: str):
+    def _get_cached_repo(self, repo_full_name: str) -> Repository:
         """
         Get a Repository object, using cache to avoid redundant API calls.
 


### PR DESCRIPTION
## Summary

- Add instance-level caching for PyGithub Repository objects in `GitHubService`
- Each `get_repo()` call was making a separate API request, doubling API usage
- For 100 files processed, API calls drop from 200 to 101

## Test plan

- [ ] Verify workers process files without errors
- [ ] Monitor GitHub API rate limit usage during scans

Fixes #172