### PR TITLE
fix: bias-scoring-service Docker build with repo root context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,8 @@ services:
     restart: always
   bias_scoring_service:
     build:
-      context: ./services/bias-scoring-service
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: services/bias-scoring-service/Dockerfile
     depends_on:
       - db
       - rabbitmq

--- a/services/bias-scoring-service/Dockerfile
+++ b/services/bias-scoring-service/Dockerfile
@@ -3,11 +3,14 @@ FROM mcr.microsoft.com/devcontainers/python:1-3.12-bullseye
 
 WORKDIR /app
 
-COPY requirements.txt ./
+COPY services/bias-scoring-service/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application files
-COPY main.py ./
+COPY services/bias-scoring-service/main.py ./
+COPY shared ./shared
+
+ENV PYTHONPATH=/app
 
 # List files to debug
 RUN ls -la /app/


### PR DESCRIPTION
## Summary

- Update bias-scoring-service Dockerfile to use full paths from repo root
- Add `COPY shared ./shared` to include the shared module needed for markdown_utils import
- Align docker-compose.yml to use `context: .` like web and worker services

Fixes #185