### PR TITLE
fix: use JSONB astext for pending LLM page count query

### DIFF
--- a/shared/application/scan_completion_service.py
+++ b/shared/application/scan_completion_service.py
@@ -1,6 +1,5 @@
 """Service for checking and finalizing scan completion"""
 import datetime
-from sqlalchemy import cast, String
 from sqlalchemy.orm import Session
 from shared.models import Page, Scan, Snippet
 from shared.utils.logging import get_logger
@@ -44,7 +43,7 @@ class ScanCompletionService:
             # Check if any pages are still pending LLM scoring
             pending_llm = self.db.query(Page).filter(
                 Page.scan_id == scan_id,
-                cast(Page.mcp_holistic['review_method'], String) == 'llm_pending'
+                Page.mcp_holistic['review_method'].astext == 'llm_pending'
             ).count()
 
             if pending_llm > 0:


### PR DESCRIPTION
## Summary

- Fix SQLAlchemy JSONB query that caused scans to complete prematurely
- Replace `cast(mcp_holistic['review_method'], String)` with `.astext` for proper text extraction

## Problem

The `cast(..., String)` approach returns the JSON string with quotes (`"llm_pending"`), but the comparison checked for `'llm_pending'` without quotes. This caused the pending page count to always return 0, allowing scans to complete while hundreds of pages were still awaiting LLM scoring.

## Solution

Use `.astext` property which extracts the raw text value from JSONB without the surrounding JSON quotes.

```python
# Before (broken):
cast(Page.mcp_holistic['review_method'], String) == 'llm_pending'

# After (fixed):
Page.mcp_holistic['review_method'].astext == 'llm_pending'
```

Fixes #189