### PR TITLE
fix: use PostgreSQL ->> operator for JSONB text extraction

### DIFF
--- a/shared/application/scan_completion_service.py
+++ b/shared/application/scan_completion_service.py
@@ -43,7 +43,7 @@ class ScanCompletionService:
             # Check if any pages are still pending LLM scoring
             pending_llm = self.db.query(Page).filter(
                 Page.scan_id == scan_id,
-                Page.mcp_holistic['review_method'].astext == 'llm_pending'
+                Page.mcp_holistic.op('->>')('review_method') == 'llm_pending'
             ).count()
 
             if pending_llm > 0:


### PR DESCRIPTION
Replace .astext accessor with .op('->>') for SQLAlchemy 2.0 compatibility. The ->> operator extracts JSON text without quotes, avoiding both the SQLAlchemy 2.0 AttributeError and the quoted string comparison issue from previous fix attempts.

Fixes #194