### PR TITLE
fix: correct rating data type mismatch in admin feedback page

### DIFF
--- a/services/web/src/routes/admin.py
+++ b/services/web/src/routes/admin.py
@@ -510,9 +510,9 @@ def get_admin_feedback(
 
     if rating:
         if rating == "up":
-            base_query = base_query.filter(UserFeedback.rating == 'thumbs_up')
+            base_query = base_query.filter(UserFeedback.rating == True)
         elif rating == "down":
-            base_query = base_query.filter(UserFeedback.rating == 'thumbs_down')
+            base_query = base_query.filter(UserFeedback.rating == False)
 
     if has_comment:
         if has_comment == "yes":
@@ -560,8 +560,8 @@ def get_admin_feedback(
     # not all feedback items in the database
     stats_query = base_query.with_entities(
         func.count(UserFeedback.id).label('total'),
-        func.sum(case((UserFeedback.rating == 'thumbs_up', 1), else_=0)).label('thumbs_up'),
-        func.sum(case((UserFeedback.rating == 'thumbs_down', 1), else_=0)).label('thumbs_down'),
+        func.sum(case((UserFeedback.rating == True, 1), else_=0)).label('thumbs_up'),
+        func.sum(case((UserFeedback.rating == False, 1), else_=0)).label('thumbs_down'),
         func.sum(case((func.coalesce(func.length(func.trim(UserFeedback.comment)), 0) > 0, 1), else_=0)).label('has_comments')
     ).first()
 

--- a/services/web/src/templates/admin_feedback.html
+++ b/services/web/src/templates/admin_feedback.html
@@ -477,7 +477,7 @@
                             {% endif %}
                         </td>
                         <td>
-                            {% if feedback.rating == 'thumbs_up' %}
+                            {% if feedback.rating == true %}
                             <span class="rating-badge up">
                                 <span>+</span> Thumbs Up
                             </span>


### PR DESCRIPTION
## Summary
- Fixed the "View All Feedback" admin page which was broken due to a data type mismatch
- The `rating` column is Boolean (`True`/`False`) but queries and templates were comparing against strings (`'thumbs_up'`/`'thumbs_down'`)
- Changed comparisons to use boolean values in `admin.py` and `admin_feedback.html`

## Test plan
- [ ] Start the dev environment with `./scripts/start-dev.sh`
- [ ] Navigate to the admin feedback page at `/admin/feedback`
- [ ] Verify feedback items are displayed (not empty)
- [ ] Verify stats show correct thumbs up/down counts (not zeros)
- [ ] Verify rating filter dropdown works correctly
- [ ] Verify individual feedback items show correct thumbs up/down badges

Fixes #197