### PR TITLE
Fix products dropdown truncated at 100 items on /flagged page

### DIFF
--- a/services/web/src/utils/docset_queries.py
+++ b/services/web/src/utils/docset_queries.py
@@ -209,7 +209,6 @@ def get_available_docsets(db: Session, limit: int = 100) -> List[str]:
             db.query(Page.doc_set)
             .filter(Page.doc_set.isnot(None))
             .distinct()
-            .limit(limit)
             .all()
         )
         


### PR DESCRIPTION
## Summary

- Remove erroneous `.limit(limit)` from the distinct docsets query in `get_available_docsets()`
- The limit was intended only for the fallback query that samples pages, not for the efficient `SELECT DISTINCT` query

## Test plan

- [ ] Verify `/flagged` page shows all 154+ products in the "Filter by Product" dropdown
- [ ] Confirm products after "load-balancer" alphabetically (e.g., logic-apps, virtual-machines) now appear

Fixes #207