### PR TITLE
perf: Remove unnecessary JOIN in homepage scan list query

### DIFF
--- a/shared/utils/bias_utils.py
+++ b/shared/utils/bias_utils.py
@@ -43,22 +43,27 @@ def get_parsed_mcp_holistic(page) -> Optional[Dict[str, Any]]:
 def is_page_biased(page):
     """
     Determine if a page needs attention based on holistic bias analysis.
-    
+
     Args:
         page: Page model instance with mcp_holistic field
-        
+
     Returns:
-        bool: True if page has bias_types (needs attention), False otherwise
+        bool: True if page has bias (severity != 'none'), False otherwise
     """
     mcp_data = get_parsed_mcp_holistic(page)
     if not mcp_data:
         return False
-    
-    # A page needs attention if it has any bias_types
+
+    # Primary check: severity field (authoritative indicator)
+    severity = mcp_data.get('severity')
+    if severity is not None and isinstance(severity, str) and severity.strip():
+        return severity.strip().lower() != 'none'
+
+    # Fallback for legacy pages without severity field: check bias_types
     bias_types = mcp_data.get('bias_types', [])
     if isinstance(bias_types, str):
         bias_types = [bias_types]
-    
+
     return bool(bias_types and len(bias_types) > 0)
 
 

--- a/tests/unit/test_bias_utils.py
+++ b/tests/unit/test_bias_utils.py
@@ -82,14 +82,14 @@ class TestIsPageBiased:
         assert is_page_biased(page) is False
 
     def test_empty_bias_types_returns_false(self):
-        """Page with empty bias_types should return False."""
+        """Page with empty bias_types (no severity) should return False."""
         page = MagicMock()
         page.mcp_holistic = {"bias_types": []}
         del page._parsed_mcp_holistic
         assert is_page_biased(page) is False
 
     def test_with_bias_types_returns_true(self):
-        """Page with bias_types should return True."""
+        """Page with bias_types (no severity) should return True via fallback."""
         page = MagicMock()
         page.mcp_holistic = {"bias_types": ["powershell_only"]}
         del page._parsed_mcp_holistic
@@ -108,6 +108,78 @@ class TestIsPageBiased:
         page.mcp_holistic = {"bias_types": "powershell_only"}
         del page._parsed_mcp_holistic
         assert is_page_biased(page) is True
+
+    # Severity-based tests (primary indicator)
+    def test_severity_high_returns_true(self):
+        """Page with severity 'high' should return True."""
+        page = MagicMock()
+        page.mcp_holistic = {"severity": "high", "bias_types": []}
+        del page._parsed_mcp_holistic
+        assert is_page_biased(page) is True
+
+    def test_severity_medium_returns_true(self):
+        """Page with severity 'medium' should return True."""
+        page = MagicMock()
+        page.mcp_holistic = {"severity": "medium", "bias_types": []}
+        del page._parsed_mcp_holistic
+        assert is_page_biased(page) is True
+
+    def test_severity_low_returns_true(self):
+        """Page with severity 'low' should return True."""
+        page = MagicMock()
+        page.mcp_holistic = {"severity": "low", "bias_types": []}
+        del page._parsed_mcp_holistic
+        assert is_page_biased(page) is True
+
+    def test_severity_none_returns_false(self):
+        """Page with severity 'none' should return False."""
+        page = MagicMock()
+        page.mcp_holistic = {"severity": "none", "bias_types": []}
+        del page._parsed_mcp_holistic
+        assert is_page_biased(page) is False
+
+    def test_severity_none_overrides_bias_types(self):
+        """Severity 'none' should take precedence over non-empty bias_types."""
+        page = MagicMock()
+        page.mcp_holistic = {"severity": "none", "bias_types": ["powershell_only"]}
+        del page._parsed_mcp_holistic
+        assert is_page_biased(page) is False
+
+    def test_severity_high_with_bias_types(self):
+        """Page with severity 'high' and bias_types should return True."""
+        page = MagicMock()
+        page.mcp_holistic = {"severity": "high", "bias_types": ["powershell_only"]}
+        del page._parsed_mcp_holistic
+        assert is_page_biased(page) is True
+
+    def test_severity_case_insensitive(self):
+        """Severity comparison should be case-insensitive."""
+        page = MagicMock()
+        page.mcp_holistic = {"severity": "HIGH", "bias_types": []}
+        del page._parsed_mcp_holistic
+        assert is_page_biased(page) is True
+
+        page.mcp_holistic = {"severity": "None", "bias_types": []}
+        del page._parsed_mcp_holistic
+        assert is_page_biased(page) is False
+
+    def test_severity_with_whitespace(self):
+        """Severity with whitespace should be handled."""
+        page = MagicMock()
+        page.mcp_holistic = {"severity": "  high  ", "bias_types": []}
+        del page._parsed_mcp_holistic
+        assert is_page_biased(page) is True
+
+    def test_empty_string_severity_falls_back_to_bias_types(self):
+        """Empty string severity should fall back to bias_types."""
+        page = MagicMock()
+        page.mcp_holistic = {"severity": "", "bias_types": ["powershell_only"]}
+        del page._parsed_mcp_holistic
+        assert is_page_biased(page) is True
+
+        page.mcp_holistic = {"severity": "", "bias_types": []}
+        del page._parsed_mcp_holistic
+        assert is_page_biased(page) is False
 
 
 class TestGetPagePriority:


### PR DESCRIPTION
## Summary

- Replace complex JOIN query that scanned 253k pages with simple query using precomputed Scan table fields
- Use `severity != 'none'` as authoritative bias indicator instead of `bias_types` array length
- Add fallback to `bias_types` for legacy data without severity field

## Changes

- **`shared/utils/bias_utils.py`**: Update `is_page_biased()` to check severity field first
- **`shared/application/scan_completion_service.py`**: Fix `biased_pages_count` computation to use severity-based logic
- **`services/web/src/main.py`**: Simplify homepage query to use precomputed `total_pages_found` and `biased_pages_count`
- **`tests/unit/test_bias_utils.py`**: Add 9 new tests for severity-based bias detection

## Performance Impact

- **Before**: O(scans × pages) - joins all 253k pages with GROUP BY
- **After**: O(scans) - simple query on Scan table (~257 rows)
- **Expected**: Query time from ~1-2s to <50ms

## Test Plan

- [x] All 252 unit tests pass
- [x] 35 bias_utils tests pass (including 9 new severity-based tests)
- [ ] Manual verification of homepage load time improvement

Fixes #213