### PR TITLE
fix: Resolve OpenTelemetry version conflict with azure-monitor-opentelemetry

### DIFF
--- a/services/web/requirements.txt
+++ b/services/web/requirements.txt
@@ -29,16 +29,11 @@ pyyaml
 # Monitoring
 prometheus-client>=0.19.0
 
-# Distributed Tracing (optional - set OTEL_EXPORTER_OTLP_ENDPOINT to enable)
-opentelemetry-api>=1.20.0
-opentelemetry-sdk>=1.20.0
-opentelemetry-exporter-otlp>=1.20.0
-opentelemetry-instrumentation-fastapi>=0.41b0
-opentelemetry-instrumentation-sqlalchemy>=0.41b0
-opentelemetry-instrumentation-requests>=0.41b0
-
-# Azure Application Insights (OpenTelemetry-based)
+# Azure Application Insights & Distributed Tracing
+# azure-monitor-opentelemetry brings compatible OpenTelemetry dependencies
+# For Jaeger fallback, set OTEL_EXPORTER_OTLP_ENDPOINT when App Insights is not configured
 azure-monitor-opentelemetry>=1.0.0
+opentelemetry-exporter-otlp  # For Jaeger/OTLP export fallback
 
 # Authentication & Security
 cryptography>=2.5


### PR DESCRIPTION
## Problem

The App Insights integration from #220 fails at runtime with:
```
ImportError: cannot import name 'LogData' from 'opentelemetry.sdk._logs'
```

## Cause

The explicit OpenTelemetry version pins (`>=1.20.0`, `>=0.41b0`) in requirements.txt conflict with what `azure-monitor-opentelemetry` expects. Pip resolves to `opentelemetry-sdk 1.39.1` but the `azure-monitor-opentelemetry-exporter` needs a different internal API.

## Fix

Remove explicit OpenTelemetry version pins and let `azure-monitor-opentelemetry` manage its own compatible dependencies. Keep `opentelemetry-exporter-otlp` for Jaeger fallback.

## Test

After merge and deploy:
```bash
kubectl logs -l app=webui -n azuredocs-app | grep -i "app insights"
```

Should show: `Azure Application Insights configured successfully`