### PR TITLE
fix: Make App Insights secret reference optional for CSI sync

### DIFF
--- a/infra/k8s/overlays/dev/webui-appinsights-patch.yaml
+++ b/infra/k8s/overlays/dev/webui-appinsights-patch.yaml
@@ -14,3 +14,4 @@ spec:
                 secretKeyRef:
                   name: azuredocs-secrets
                   key: APPLICATIONINSIGHTS_CONNECTION_STRING
+                  optional: true

--- a/infra/k8s/overlays/prod/webui-appinsights-patch.yaml
+++ b/infra/k8s/overlays/prod/webui-appinsights-patch.yaml
@@ -14,3 +14,4 @@ spec:
                 secretKeyRef:
                   name: azuredocs-secrets
                   key: APPLICATIONINSIGHTS_CONNECTION_STRING
+                  optional: true


### PR DESCRIPTION
Prevents chicken-and-egg problem where pods can't start without the secret, but the secret only syncs when pods mount the CSI volume.