### PR TITLE
fix: Use JSON-compatible operators for scan finalization

### DIFF
--- a/shared/application/scan_completion_service.py
+++ b/shared/application/scan_completion_service.py
@@ -90,13 +90,13 @@ class ScanCompletionService:
                 or_(
                     # Primary: severity exists and is not 'none'
                     and_(
-                        Page.mcp_holistic['severity'].astext.isnot(None),
-                        func.lower(Page.mcp_holistic['severity'].astext) != 'none'
+                        Page.mcp_holistic.op('->>')('severity').isnot(None),
+                        func.lower(Page.mcp_holistic.op('->>')('severity')) != 'none'
                     ),
                     # Fallback: severity missing but bias_types array is non-empty
                     and_(
-                        Page.mcp_holistic['severity'].astext.is_(None),
-                        func.jsonb_array_length(func.coalesce(Page.mcp_holistic['bias_types'], '[]')) > 0
+                        Page.mcp_holistic.op('->>')('severity').is_(None),
+                        func.json_array_length(Page.mcp_holistic.op('->')('bias_types')) > 0
                     )
                 )
             ).count()


### PR DESCRIPTION
## Summary

- Fixes silent crash in `ScanCompletionService._finalize_scan()` that prevented all scans from completing
- Replaced JSONB-specific `.astext` and `jsonb_array_length` with JSON-compatible `.op('->>') ` / `.op('->')` and `json_array_length` operators, matching the `Column(JSON)` type defined in the model

Closes #224

## Test plan

- [ ] Verify scans transition from `in_progress` to `completed` after all files are processed
- [ ] Verify `biased_pages_count` is correctly populated on finalized scans
- [ ] Verify bias snapshots are updated after scan completion