### PR TITLE
fix: Dashboard shows 0 pages reviewed/flagged

### DIFF
--- a/services/worker/src/scan_orchestrator.py
+++ b/services/worker/src/scan_orchestrator.py
@@ -139,6 +139,7 @@ class ScanOrchestrator:
             scan.total_files_discovered = files_queued
             scan.total_files_queued = files_queued
             scan.total_files_completed = 0
+            scan.total_pages_found = files_queued
             self.db.commit()
             
             # Record successful scan initiation

--- a/shared/application/scan_completion_service.py
+++ b/shared/application/scan_completion_service.py
@@ -112,6 +112,7 @@ class ScanCompletionService:
             scan.finished_at = datetime.datetime.now(datetime.timezone.utc)
             scan.biased_pages_count = biased_pages_count
             scan.flagged_snippets_count = flagged_snippets_count
+            scan.total_pages_found = processed_pages + error_pages
 
             # Set last_commit_sha for future incremental scans
             if scan.working_commit_sha:


### PR DESCRIPTION
## Summary
- Populates `total_pages_found` on the `Scan` model so the main dashboard displays correct page counts
- Sets an initial estimate (`files_queued`) during discovery so counts appear while a scan is still running
- Sets the authoritative final count (`processed_pages + error_pages`) during scan finalization

Fixes #225

## Test plan
- [x] Unit tests pass (252/252)
- [ ] Trigger a scan and confirm the dashboard shows non-zero "Pages Reviewed" and "Flagged" counts after completion
- [ ] Verify the scan detail view still shows correct counts